### PR TITLE
qt5-base package is non-existent; use qt5-base-common

### DIFF
--- a/adtool.spec
+++ b/adtool.spec
@@ -22,7 +22,7 @@ BuildRequires: doxygen
 
 Requires: openldap
 Requires: libsasl2
-Requires: qt5-base
+Requires: qt5-base-common
 
 Source0: %name-%version.tar
 


### PR DESCRIPTION
I've tried to install `adtool` package on my `p9`-based system and it failed to find `qt5-base` dependency. It is needed to use `qt5-base-common` instead.