### PR TITLE
Drag drop groups

### DIFF
--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -441,7 +441,7 @@ DropType get_drop_type(const QString &dn, const QString &target_dn) {
         } else if (target_is_group) {
             return DropType_AddToGroup;
         }
-    } else if (dropped_is_group || dropped_is_ou) {
+    } else if (dropped_is_group) {
         if (target_is_ou || target_is_container || target_is_container_like) {
             return DropType_Move;
         }

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -405,6 +405,18 @@ bool AdInterface::is_policy(const QString &dn) {
     return attribute_value_exists(dn, "objectClass", "groupPolicyContainer");
 }
 
+bool AdInterface::is_container_like(const QString &dn) {
+    // TODO: check that this includes all fitting objectClasses
+    const QList<QString> containerlike_objectClasses = {"organizationalUnit", "builtinDomain", "domain"};
+    for (auto c : containerlike_objectClasses) {
+        if (AD()->attribute_value_exists(dn, "objectClass", c)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 bool AdInterface::can_drop_entry(const QString &dn, const QString &target_dn) {
     const bool dropped_is_user = AD()->is_user(dn);
 

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -427,15 +427,24 @@ enum DropType {
 // If drop type is none, then can't drop this entry on this target
 DropType get_drop_type(const QString &dn, const QString &target_dn) {
     const bool dropped_is_user = AD()->is_user(dn);
+    const bool dropped_is_group = AD()->is_group(dn);
+    const bool dropped_is_ou = AD()->is_ou(dn);
 
     const bool target_is_group = AD()->is_group(target_dn);
     const bool target_is_ou = AD()->is_ou(target_dn);
     const bool target_is_container = AD()->is_container(target_dn);
+    const bool target_is_container_like = AD()->is_container_like(target_dn);
 
-    if (dropped_is_user && (target_is_ou || target_is_container)) {
-        return DropType_Move;
-    } else if (dropped_is_user && target_is_group) {
-        return DropType_AddToGroup;
+    if (dropped_is_user) {
+        if (target_is_ou || target_is_container) {
+            return DropType_Move;
+        } else if (target_is_group) {
+            return DropType_AddToGroup;
+        }
+    } else if (dropped_is_group || dropped_is_ou) {
+        if (target_is_ou || target_is_container || target_is_container_like) {
+            return DropType_Move;
+        }
     }
 
     return DropType_None;

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -319,9 +319,9 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
             reload_attributes_of_entry_groups(new_dn);
         }
 
-        // emit move_user_complete(user_dn, container_dn, new_dn);
+        emit move_complete(dn, new_container, new_dn);
     } else {
-        // emit move_user_failed(user_dn, container_dn, new_dn, get_error_str());
+        emit move_failed(dn, new_container, new_dn, get_error_str());
     }
 }
 

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -301,7 +301,15 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
     const QByteArray new_container_array = new_container.toLatin1();
     const char *new_container_cstr = new_container_array.constData();
 
+    const bool entry_is_group = is_user(dn);
     const bool entry_is_user = is_user(dn);
+
+    if (!entry_is_user && !entry_is_group) {
+        emit move_failed(dn, new_container, new_dn, "AdInterface::move() only supports moving users and groups at the moment");
+
+        return;
+    }
+
     if (entry_is_user) {
         result = connection->move_user(dn_cstr, new_container_cstr);
     } else {
@@ -428,7 +436,6 @@ enum DropType {
 DropType get_drop_type(const QString &dn, const QString &target_dn) {
     const bool dropped_is_user = AD()->is_user(dn);
     const bool dropped_is_group = AD()->is_group(dn);
-    const bool dropped_is_ou = AD()->is_ou(dn);
 
     const bool target_is_group = AD()->is_group(target_dn);
     const bool target_is_ou = AD()->is_ou(target_dn);

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -397,16 +397,16 @@ bool AdInterface::is_policy(const QString &dn) {
     return attribute_value_exists(dn, "objectClass", "groupPolicyContainer");
 }
 
-bool AdInterface::can_drop_entry(const QString &dn, const QString &parent_dn) {
+bool AdInterface::can_drop_entry(const QString &dn, const QString &target_dn) {
     const bool dropped_is_user = AD()->is_user(dn);
 
-    const bool parent_is_group = AD()->is_group(parent_dn);
-    const bool parent_is_ou = AD()->is_ou(parent_dn);
-    const bool parent_is_container = AD()->is_container(parent_dn);
+    const bool parent_is_group = AD()->is_group(target_dn);
+    const bool parent_is_ou = AD()->is_ou(target_dn);
+    const bool parent_is_container = AD()->is_container(target_dn);
 
     // TODO: support dropping non-users
     // TODO: support dropping policies
-    if (parent_dn == "") {
+    if (target_dn == "") {
         return false;
     } else if (dropped_is_user && (parent_is_group || parent_is_ou || parent_is_container)) {
         return true;
@@ -416,17 +416,17 @@ bool AdInterface::can_drop_entry(const QString &dn, const QString &parent_dn) {
 }
 
 // General "drop" operation that can either move, link or change membership depending on which types of entries are involved
-void AdInterface::drop_entry(const QString &dn, const QString &parent_dn) {
+void AdInterface::drop_entry(const QString &dn, const QString &target_dn) {
     const bool dropped_is_user = AD()->is_user(dn);
 
-    const bool parent_is_group = AD()->is_group(parent_dn);
-    const bool parent_is_ou = AD()->is_ou(parent_dn);
-    const bool parent_is_container = AD()->is_container(parent_dn);
+    const bool parent_is_group = AD()->is_group(target_dn);
+    const bool parent_is_ou = AD()->is_ou(target_dn);
+    const bool parent_is_container = AD()->is_container(target_dn);
 
     if (dropped_is_user && (parent_is_ou || parent_is_container)) {
-        AD()->move_user(dn, parent_dn);
+        AD()->move_user(dn, target_dn);
     } else if (dropped_is_user && parent_is_group) {
-        AD()->add_user_to_group(parent_dn, dn);
+        AD()->add_user_to_group(target_dn, dn);
     }
 }
 

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -420,15 +420,15 @@ bool AdInterface::is_container_like(const QString &dn) {
 bool AdInterface::can_drop_entry(const QString &dn, const QString &target_dn) {
     const bool dropped_is_user = AD()->is_user(dn);
 
-    const bool parent_is_group = AD()->is_group(target_dn);
-    const bool parent_is_ou = AD()->is_ou(target_dn);
-    const bool parent_is_container = AD()->is_container(target_dn);
+    const bool target_is_group = AD()->is_group(target_dn);
+    const bool target_is_ou = AD()->is_ou(target_dn);
+    const bool target_is_container = AD()->is_container(target_dn);
 
     // TODO: support dropping non-users
     // TODO: support dropping policies
     if (target_dn == "") {
         return false;
-    } else if (dropped_is_user && (parent_is_group || parent_is_ou || parent_is_container)) {
+    } else if (dropped_is_user && (target_is_group || target_is_ou || target_is_container)) {
         return true;
     } else {
         return false;
@@ -439,13 +439,13 @@ bool AdInterface::can_drop_entry(const QString &dn, const QString &target_dn) {
 void AdInterface::drop_entry(const QString &dn, const QString &target_dn) {
     const bool dropped_is_user = AD()->is_user(dn);
 
-    const bool parent_is_group = AD()->is_group(target_dn);
-    const bool parent_is_ou = AD()->is_ou(target_dn);
-    const bool parent_is_container = AD()->is_container(target_dn);
+    const bool target_is_group = AD()->is_group(target_dn);
+    const bool target_is_ou = AD()->is_ou(target_dn);
+    const bool target_is_container = AD()->is_container(target_dn);
 
-    if (dropped_is_user && (parent_is_ou || parent_is_container)) {
+    if (dropped_is_user && (target_is_ou || target_is_container)) {
         AD()->move(dn, target_dn);
-    } else if (dropped_is_user && parent_is_group) {
+    } else if (dropped_is_user && target_is_group) {
         AD()->add_user_to_group(target_dn, dn);
     }
 }

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -301,7 +301,7 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
     const QByteArray new_container_array = new_container.toLatin1();
     const char *new_container_cstr = new_container_array.constData();
 
-    const bool entry_is_group = is_user(dn);
+    const bool entry_is_group = is_group(dn);
     const bool entry_is_user = is_user(dn);
 
     if (!entry_is_user && !entry_is_group) {

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -123,7 +123,7 @@ private:
     QSet<QString> attributes_loaded;
 
     void load_attributes(const QString &dn);
-    void reload_attributes_of_entry_groups(const QString &dn);
+    void update_related_entries(const QString &dn);
 
 }; 
 

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -107,8 +107,8 @@ signals:
     void create_entry_complete(const QString &dn, NewEntryType type);
     void create_entry_failed(const QString &dn, NewEntryType type, const QString &error_str);
 
-    void move_user_complete(const QString &user_dn, const QString &container_dn, const QString &new_dn);
-    void move_user_failed(const QString &user_dn, const QString &container_dn, const QString &new_dn, const QString &error_str);
+    void move_complete(const QString &dn, const QString &new_container, const QString &new_dn);
+    void move_failed(const QString &dn, const QString &new_container, const QString &new_dn, const QString &error_str);
     
     void add_user_to_group_complete(const QString &group_dn, const QString &user_dn);
     void add_user_to_group_failed(const QString &group_dn, const QString &user_dn, const QString &error_str);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -76,7 +76,7 @@ public:
     bool set_attribute(const QString &dn, const QString &attribute, const QString &value);
     bool create_entry(const QString &name, const QString &dn, NewEntryType type);
     void delete_entry(const QString &dn);
-    void move_user(const QString &user_dn, const QString &container_dn);
+    void move(const QString &dn, const QString &new_container);
     void add_user_to_group(const QString &group_dn, const QString &user_dn);
     void rename(const QString &dn, const QString &new_name);
 

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -86,8 +86,8 @@ public:
     bool is_ou(const QString &dn);
     bool is_policy(const QString &dn);
 
-    bool can_drop_entry(const QString &dn, const QString &parent_dn);
-    void drop_entry(const QString &dn, const QString &parent_dn);
+    bool can_drop_entry(const QString &dn, const QString &target_dn);
+    void drop_entry(const QString &dn, const QString &target_dn);
 
 signals:
     void ad_interface_login_complete(const QString &base, const QString &head);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -86,6 +86,9 @@ public:
     bool is_ou(const QString &dn);
     bool is_policy(const QString &dn);
 
+    bool can_drop_entry(const QString &dn, const QString &parent_dn);
+    void drop_entry(const QString &dn, const QString &parent_dn);
+
 signals:
     void ad_interface_login_complete(const QString &base, const QString &head);
     void ad_interface_login_failed(const QString &base, const QString &head);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -85,6 +85,7 @@ public:
     bool is_container(const QString &dn);
     bool is_ou(const QString &dn);
     bool is_policy(const QString &dn);
+    bool is_container_like(const QString &dn);
 
     bool can_drop_entry(const QString &dn, const QString &target_dn);
     void drop_entry(const QString &dn, const QString &target_dn);

--- a/src/ad_model.cpp
+++ b/src/ad_model.cpp
@@ -221,7 +221,7 @@ void load_row(QList<QStandardItem *> row, const QString &dn) {
 
     bool showInAdvancedViewOnly = AD()->get_attribute(dn, "showInAdvancedViewOnly") == "TRUE";
 
-    bool is_container = AD()->is_container_like(dn);
+    bool is_container = AD()->is_container_like(dn) || AD()->is_container(dn);
 
     QStandardItem *name_item = row[AdModel::Column::Name];
     QStandardItem *category_item = row[AdModel::Column::Category];

--- a/src/ad_model.cpp
+++ b/src/ad_model.cpp
@@ -221,14 +221,7 @@ void load_row(QList<QStandardItem *> row, const QString &dn) {
 
     bool showInAdvancedViewOnly = AD()->get_attribute(dn, "showInAdvancedViewOnly") == "TRUE";
 
-    bool is_container = false;
-    const QList<QString> container_objectClasses = {"container", "organizationalUnit", "builtinDomain", "domain"};
-    for (auto c : container_objectClasses) {
-        if (AD()->attribute_value_exists(dn, "objectClass", c)) {
-            is_container = true;
-            break;
-        }
-    }
+    bool is_container = AD()->is_container_like(dn);
 
     QStandardItem *name_item = row[AdModel::Column::Name];
     QStandardItem *category_item = row[AdModel::Column::Category];

--- a/src/ad_model.cpp
+++ b/src/ad_model.cpp
@@ -126,7 +126,7 @@ void AdModel::on_move_complete(const QString &dn, const QString &new_container, 
 
     // Need to load entry at new parent if the parent has already
     // been expanded/fetched
-    // NOTE: loading if parent has already been fetched will
+    // NOTE: loading if parent hasn't been fetched will
     // create a duplicate
     QList<QStandardItem *> parent_items = findItems(new_container, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
     if (parent_items.size() > 0) {

--- a/src/ad_model.cpp
+++ b/src/ad_model.cpp
@@ -42,8 +42,8 @@ AdModel::AdModel(QObject *parent)
         AD(), &AdInterface::delete_entry_complete,
         this, &AdModel::on_delete_entry_complete);
     connect(
-        AD(), &AdInterface::move_user_complete,
-        this, &AdModel::on_move_user_complete);
+        AD(), &AdInterface::move_complete,
+        this, &AdModel::on_move_complete);
     connect(
         AD(), &AdInterface::create_entry_complete,
         this, &AdModel::on_create_entry_complete);
@@ -114,9 +114,9 @@ void AdModel::on_delete_entry_complete(const QString &dn) {
     }
 }
 
-void AdModel::on_move_user_complete(const QString &user_dn, const QString &container_dn, const QString &new_dn) {
+void AdModel::on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn) {
     // Remove old entry from model
-    QList<QStandardItem *> old_items = findItems(user_dn, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
+    QList<QStandardItem *> old_items = findItems(dn, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
     if (old_items.size() > 0) {
         QStandardItem *dn_item = old_items[0];
         QModelIndex dn_index = dn_item->index();
@@ -128,7 +128,7 @@ void AdModel::on_move_user_complete(const QString &user_dn, const QString &conta
     // been expanded/fetched
     // NOTE: loading if parent has already been fetched will
     // create a duplicate
-    QList<QStandardItem *> parent_items = findItems(container_dn, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
+    QList<QStandardItem *> parent_items = findItems(new_container, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
     if (parent_items.size() > 0) {
         QStandardItem *parent_dn_item = parent_items[0];
         QModelIndex parent_dn_index = parent_dn_item->index();

--- a/src/ad_model.h
+++ b/src/ad_model.h
@@ -56,7 +56,7 @@ private slots:
     void on_ad_interface_login_complete(const QString &search_base, const QString &head_dn);
     void on_load_attributes_complete(const QString &dn);
     void on_delete_entry_complete(const QString &dn); 
-    void on_move_user_complete(const QString &user_dn, const QString &container_dn, const QString &new_dn);
+    void on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn);
     void on_create_entry_complete(const QString &dn, NewEntryType type); 
     void on_rename_complete(const QString &dn, const QString &new_name, const QString &new_dn); 
 

--- a/src/details_widget.cpp
+++ b/src/details_widget.cpp
@@ -42,8 +42,8 @@ DetailsWidget::DetailsWidget()
         AD(), &AdInterface::delete_entry_complete,
         this, &DetailsWidget::on_delete_entry_complete);
     connect(
-        AD(), &AdInterface::move_user_complete,
-        this, &DetailsWidget::on_move_user_complete);
+        AD(), &AdInterface::move_complete,
+        this, &DetailsWidget::on_move_complete);
     connect(
         AD(), &AdInterface::load_attributes_complete,
         this, &DetailsWidget::on_load_attributes_complete);
@@ -96,9 +96,9 @@ void DetailsWidget::on_delete_entry_complete(const QString &dn) {
     }
 }
 
-void DetailsWidget::on_move_user_complete(const QString &user_dn, const QString &container_dn, const QString &new_dn) {
+void DetailsWidget::on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn) {
     // Switch to the entry at new dn (entry stays the same)
-    if (target_dn == user_dn) {
+    if (target_dn == dn) {
         change_target(new_dn);
     }
 }

--- a/src/details_widget.h
+++ b/src/details_widget.h
@@ -41,7 +41,7 @@ public:
 private slots:
     void on_ad_interface_login_complete(const QString &search_base, const QString &head_dn);
     void on_delete_entry_complete(const QString &dn); 
-    void on_move_user_complete(const QString &user_dn, const QString &container_dn, const QString &new_dn); 
+    void on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn); 
     void on_load_attributes_complete(const QString &dn);
     void on_rename_complete(const QString &dn, const QString &new_name, const QString &new_dn);
     

--- a/src/entry_model.cpp
+++ b/src/entry_model.cpp
@@ -51,9 +51,9 @@ QMimeData *EntryModel::mimeData(const QModelIndexList &indexes) const {
 
 bool EntryModel::canDropMimeData(const QMimeData *data, Qt::DropAction, int, int, const QModelIndex &parent) const {
     const QString dn = data->text();
-    const QString parent_dn = get_dn_from_index(parent);
+    const QString target_dn = get_dn_from_index(parent);
 
-    const bool can_drop = AD()->can_drop_entry(dn, parent_dn);
+    const bool can_drop = AD()->can_drop_entry(dn, target_dn);
 
     return can_drop;
 }
@@ -68,9 +68,9 @@ bool EntryModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int 
     }
 
     const QString dn = data->text();
-    const QString parent_dn = get_dn_from_index(parent);
+    const QString target_dn = get_dn_from_index(parent);
 
-    AD()->drop_entry(dn, parent_dn);
+    AD()->drop_entry(dn, target_dn);
 
     return true;
 }

--- a/src/entry_model.cpp
+++ b/src/entry_model.cpp
@@ -53,21 +53,9 @@ bool EntryModel::canDropMimeData(const QMimeData *data, Qt::DropAction, int, int
     const QString dn = data->text();
     const QString parent_dn = get_dn_from_index(parent);
 
-    const bool dropped_is_user = AD()->is_user(dn);
+    const bool can_drop = AD()->can_drop_entry(dn, parent_dn);
 
-    const bool parent_is_group = AD()->is_group(parent_dn);
-    const bool parent_is_ou = AD()->is_ou(parent_dn);
-    const bool parent_is_container = AD()->is_container(parent_dn);
-
-    // TODO: support dropping non-users
-    // TODO: support dropping policies
-    if (parent_dn == "") {
-        return false;
-    } else if (dropped_is_user && (parent_is_group || parent_is_ou || parent_is_container)) {
-        return true;
-    } else {
-        return false;
-    }
+    return can_drop;
 }
 
 bool EntryModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) {
@@ -82,17 +70,7 @@ bool EntryModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int 
     const QString dn = data->text();
     const QString parent_dn = get_dn_from_index(parent);
 
-    const bool dropped_is_user = AD()->is_user(dn);
-
-    const bool parent_is_group = AD()->is_group(parent_dn);
-    const bool parent_is_ou = AD()->is_ou(parent_dn);
-    const bool parent_is_container = AD()->is_container(parent_dn);
-
-    if (dropped_is_user && (parent_is_ou || parent_is_container)) {
-        AD()->move_user(dn, parent_dn);
-    } else if (dropped_is_user && parent_is_group) {
-        AD()->add_user_to_group(parent_dn, dn);
-    }
+    AD()->drop_entry(dn, parent_dn);
 
     return true;
 }

--- a/src/members_model.cpp
+++ b/src/members_model.cpp
@@ -27,6 +27,10 @@ MembersModel::MembersModel(QObject *parent)
 {
     setHorizontalHeaderItem(Column::Name, new QStandardItem("Name"));
     setHorizontalHeaderItem(Column::DN, new QStandardItem("DN"));
+
+    connect(
+        AD(), &AdInterface::move_complete,
+        this, &MembersModel::on_move_complete);
 }
 
 void MembersModel::change_target(const QString &new_target_dn) {
@@ -59,5 +63,15 @@ QString MembersModel::get_dn_from_index(const QModelIndex &index) const {
         return target_dn;
     } else {
         return EntryModel::get_dn_from_index(index);
+    }
+}
+
+void MembersModel::on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn) {
+    // If entry is in members model, need to update it's dn
+    QList<QStandardItem *> items = findItems(dn, Qt::MatchExactly | Qt::MatchRecursive, Column::DN);
+
+    if (items.size() > 0) {
+        QStandardItem *dn_item = items[Column::DN];
+        dn_item->setText(new_dn);
     }
 }

--- a/src/members_model.h
+++ b/src/members_model.h
@@ -41,6 +41,9 @@ public:
 
     void change_target(const QString &new_target_dn);
 
+private slots:
+    void on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn);
+
 private:
     QString target_dn;
 

--- a/src/status_bar.cpp
+++ b/src/status_bar.cpp
@@ -61,11 +61,11 @@ StatusBar::StatusBar()
         this, &StatusBar::on_create_entry_failed);
     
     connect(
-        AD(), &AdInterface::move_user_complete,
-        this, &StatusBar::on_move_user_complete);
+        AD(), &AdInterface::move_complete,
+        this, &StatusBar::on_move_complete);
     connect(
-        AD(), &AdInterface::move_user_failed,
-        this, &StatusBar::on_move_user_failed);
+        AD(), &AdInterface::move_failed,
+        this, &StatusBar::on_move_failed);
 
     connect(
         AD(), &AdInterface::add_user_to_group_complete,
@@ -128,8 +128,8 @@ void StatusBar::on_create_entry_complete(const QString &dn, NewEntryType type) {
 
     showMessage(msg);
 }
-void StatusBar::on_move_user_complete(const QString &user_dn, const QString &container_dn, const QString &new_dn) {
-    QString msg = QString("Moved entry \"%1\" to \"%2\"").arg(user_dn).arg(new_dn);
+void StatusBar::on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn) {
+    QString msg = QString("Moved \"%1\" to \"%2\"").arg(dn).arg(new_container);
 
     showMessage(msg);
 }
@@ -157,8 +157,8 @@ void StatusBar::on_create_entry_failed(const QString &dn, NewEntryType type, con
 
     showMessage(msg);
 }
-void StatusBar::on_move_user_failed(const QString &user_dn, const QString &container_dn, const QString &new_dn, const QString &error_str) {
-    QString msg = QString("Failed to move user \"%1\". Error: \"%2\"").arg(user_dn, error_str);
+void StatusBar::on_move_failed(const QString &dn, const QString &new_container, const QString &new_dn, const QString &error_str) {
+    QString msg = QString("Failed to move \"%1\" to \"%2\". Error: \"%3\"").arg(dn, new_container, error_str);
 
     showMessage(msg);
 }

--- a/src/status_bar.h
+++ b/src/status_bar.h
@@ -50,8 +50,8 @@ private slots:
     void on_create_entry_complete(const QString &dn, NewEntryType type);
     void on_create_entry_failed(const QString &dn, NewEntryType type, const QString &error_str);
 
-    void on_move_user_complete(const QString &user_dn, const QString &container_dn, const QString &new_dn);
-    void on_move_user_failed(const QString &user_dn, const QString &container_dn, const QString &new_dn, const QString &error_str);
+    void on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn);
+    void on_move_failed(const QString &dn, const QString &new_container, const QString &new_dn, const QString &error_str);
 
     void on_add_user_to_group_complete(const QString &group_dn, const QString &user_dn);
     void on_add_user_to_group_failed(const QString &group_dn, const QString &user_dn, const QString &error_str);


### PR DESCRIPTION
Change move_user() to move() which calls AdConnection's move() or move_user() depending on entry type.
Move drag drop logic into ad_interface.
Add is_container_like() to distinguish from is_container()..
When a group is moved, update it's member entries.
    Also update member entries on other group modifications.
Update DN of entry in MembersModel when entry is moved.

(moving OU's is too complicated, will finish in future PR)