### PR TITLE
add change_dn_internal()

### DIFF
--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -117,13 +117,21 @@ signals:
     void rename_complete(const QString &dn, const QString &new_name, const QString &new_dn);
     void rename_failed(const QString &dn, const QString &new_name, const QString &new_dn, const QString &error_str);
 
+    void attribute_added(const QString &dn, const QString &attribute, const QString &value);
+    void attribute_removed(const QString &dn, const QString &attribute, const QString &value);
+    void attribute_replaced(const QString &dn, const QString &attribute, const QString &old_value, const QString &new_value);
+
+
 private:
     adldap::AdConnection *connection = nullptr;
     QMap<QString, QMap<QString, QList<QString>>> attributes_map;
     QSet<QString> attributes_loaded;
 
     void load_attributes(const QString &dn);
-    void update_related_entries(const QString &dn);
+    void add_attribute_internal(const QString &dn, const QString &attribute, const QString &value);
+    void remove_attribute_internal(const QString &dn, const QString &attribute, const QString &value);
+    void replace_attribute_internal(const QString &dn, const QString &attribute, const QString &old_value, const QString &new_value);
+    void change_dn_internal(const QString &old_dn, const QString &new_dn);
 
 }; 
 


### PR DESCRIPTION
\ replaces and extends update_related_entries()
update internal state related through membership
emit more specific signal for attribute changes
avoid LDAP request in add_user_to_group()

Before AdInterface called load_attributes() after every operation that affected entries. Every load_attributes() call makes an LDAP request. This PR instead only calls load_attributes() when needed, 

Use less load_attributes() which makes an LDAP request each time and instead update attributes internally.
Updating related entries affected by an AD operation is now fully covered for membership case. Policy and child relationship will be covered in the future.
Emit better, more specific signals for attribute changes (haven't connected widgets yet).