### PR TITLE
update cache after AD operations

### DIFF
--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -473,8 +473,7 @@ void AdInterface::drop_entry(const QString &dn, const QString &target_dn) {
     }
 }
 
-// Update all attributes that contain this dn, by deleting
-// or replacing with new one
+// Update cache for this entry and all related entries
 // LDAP database does all this on it's own so need to replicate it
 // NOTE: if entry was deleted, new_dn should be ""
 void AdInterface::update_cache(const QString &old_dn, const QString &new_dn) {

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -273,7 +273,7 @@ void AdInterface::delete_entry(const QString &dn) {
     if (result == AD_SUCCESS) {
         update_related_entries(dn, "");
         
-        unload_internal_attributes(old_dn);
+        unload_internal_attributes(dn);
 
         emit delete_entry_complete(dn);
     } else {
@@ -310,12 +310,12 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
     
     if (result == AD_SUCCESS) {
         // Copy attributes to new_dn
-        attributes_map[new_dn] = attributes_map[old_dn];
+        attributes_map[new_dn] = attributes_map[dn];
         attributes_loaded.insert(new_dn);
 
         update_related_entries(dn, new_dn);
 
-        unload_internal_attributes(old_dn);
+        unload_internal_attributes(dn);
 
         emit move_complete(dn, new_container, new_dn);
     } else {
@@ -379,7 +379,7 @@ void AdInterface::rename(const QString &dn, const QString &new_name) {
 
         update_related_entries(dn, new_dn);
 
-        unload_internal_attributes(old_dn);
+        unload_internal_attributes(dn);
 
         emit rename_complete(dn, new_name, new_dn);
     } else {
@@ -480,7 +480,7 @@ void AdInterface::drop_entry(const QString &dn, const QString &target_dn) {
     }
 }
 
-void unload_internal_attributes(const QString &dn) {
+void AdInterface::unload_internal_attributes(const QString &dn) {
     attributes_map.remove(dn);
     attributes_loaded.remove(dn);
 }

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -306,9 +306,13 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
     }
     
     if (result == AD_SUCCESS) {
-        // Copy attributes to new_dn
-        attributes_map[new_dn] = attributes_map[dn];
-        attributes_loaded_set.insert(new_dn);
+        // Load or copy attributes to new_dn
+        if (attributes_loaded(dn)) {
+            attributes_map[new_dn] = attributes_map[dn];
+            attributes_loaded_set.insert(new_dn);
+        } else {
+            load_attributes(new_dn);
+        }
 
         update_related_entries(dn, new_dn);
 
@@ -333,8 +337,12 @@ void AdInterface::add_user_to_group(const QString &group_dn, const QString &user
 
     if (result == AD_SUCCESS) {
         // Update attributes of user and group
-        add_attribute_internal(group_dn, "member", user_dn);
-        add_attribute_internal(user_dn, "memberOf", group_dn);
+        if (attributes_loaded(group_dn)) {
+            add_attribute_internal(group_dn, "member", user_dn);
+        }
+        if (attributes_loaded(group_dn)) {
+            add_attribute_internal(user_dn, "memberOf", group_dn);
+        }
 
         emit add_user_to_group_complete(group_dn, user_dn);
     } else {

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -511,11 +511,9 @@ void AdInterface::replace_attribute_internal(const QString &dn, const QString &a
 // to this one through membership
 // LDAP database does all this on it's own so need to replicate it
 // NOTE: if entry was deleted, new_dn should be ""
-// NOTE: if entry was created, old_dn should be ""
 // NOTE: attributes_map should contain both new_dn and old_dn when
 // this is called, so that signals/connections can access both
 void AdInterface::update_related_entries(const QString &old_dn, const QString &new_dn) {
-    const bool created = (old_dn == "" && new_dn != "");
     const bool deleted = (old_dn != "" && new_dn == "");
     const bool changed = (old_dn != "" && new_dn != "" && old_dn != new_dn);
 
@@ -531,9 +529,7 @@ void AdInterface::update_related_entries(const QString &old_dn, const QString &n
     for (auto group : groups) {
         // Only update if loaded
         if (attributes_loaded.contains(group)) {
-            if (created) {
-                add_attribute_internal(group, "member", new_dn);
-            } else if (deleted) {
+            if (deleted) {
                 remove_attribute_internal(group, "member", old_dn);
             } else if (changed) {
                 replace_attribute_internal(group, "member", old_dn, new_dn);
@@ -546,9 +542,7 @@ void AdInterface::update_related_entries(const QString &old_dn, const QString &n
     for (auto member : members) {
         // Only update if loaded
         if (attributes_loaded.contains(member)) {
-            if (created) {
-                add_attribute_internal(member, "memberOf", new_dn);
-            } else if (deleted) {
+            if (deleted) {
                 remove_attribute_internal(member, "memberOf", old_dn);
             } else if (changed) {
                 replace_attribute_internal(member, "memberOf", old_dn, new_dn);

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -311,10 +311,10 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
     }
 }
 
-void AdInterface::add_attribute_internal(const QString &dn, const QString &attribute, const QString &dn) {
+void AdInterface::add_attribute_internal(const QString &dn, const QString &attribute, const QString &value) {
     // TODO: insert attributes near other attributes with same name
-    if (attributes_loaded.contains(group_dn)) {
-        attributes_map[dn][attribute].append(dn);
+    if (attributes_loaded.contains(dn)) {
+        attributes_map[dn][attribute].append(value);
 
         emit attributes_changed(dn);
     }

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -141,9 +141,6 @@ void AdInterface::load_attributes(const QString &dn) {
 }
 
 QMap<QString, QList<QString>> AdInterface::get_attributes(const QString &dn) {
-    // First check whether load_attributes was ever called on this dn
-    // If it hasn't, attempt to load attributes
-    // After that return whatever attributes are now loaded for this dn
     if (!attributes_loaded(dn)) {
         load_attributes(dn);
     }

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -264,11 +264,10 @@ void AdInterface::delete_entry(const QString &dn) {
     result = connection->object_delete(dn_cstr);
 
     if (result == AD_SUCCESS) {
-        update_related_entries(dn, "");
-        
-        emit delete_entry_complete(dn);
-    
+        update_related_entries(dn, "");    
         unload_internal_attributes(dn);
+
+        emit delete_entry_complete(dn);
     } else {
         emit delete_entry_failed(dn, get_error_str());
     }
@@ -310,11 +309,10 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
         load_attributes(new_dn);
 
         update_related_entries(dn, new_dn);
+        unload_internal_attributes(dn);
 
         emit dn_changed(dn, new_dn);
         emit move_complete(dn, new_container, new_dn);
-
-        unload_internal_attributes(dn);
     } else {
         emit move_failed(dn, new_container, new_dn, get_error_str());
     }
@@ -386,12 +384,11 @@ void AdInterface::rename(const QString &dn, const QString &new_name) {
         load_attributes(new_dn);
 
         update_related_entries(dn, new_dn);
+        unload_internal_attributes(dn);
 
         emit dn_changed(dn, new_dn);
         emit attributes_changed(new_dn);
         emit rename_complete(dn, new_name, new_dn);
-
-        unload_internal_attributes(dn);
     } else {
         emit rename_failed(dn, new_name, new_dn, get_error_str());
     }

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -257,9 +257,8 @@ bool AdInterface::create_entry(const QString &name, const QString &dn, NewEntryT
 }
 
 void AdInterface::delete_entry(const QString &dn) {
-    // Load attributes so they are available for objects
-    // connecting to signals
-    // NOTE: have to do this because operation
+    // Load attributes so they are available for objects connecting to signals
+    // NOTE: have to do this before operation
     if (!attributes_loaded(dn)) {
         load_attributes(dn);
     }
@@ -283,9 +282,8 @@ void AdInterface::delete_entry(const QString &dn) {
 }
 
 void AdInterface::move(const QString &dn, const QString &new_container) {
-    // Load attributes so they are available for objects
-    // connecting to signals
-    // NOTE: have to do this because operation
+    // Load attributes so they are available for objects connecting to signals
+    // NOTE: have to do this before operation
     if (!attributes_loaded(dn)) {
         load_attributes(dn);
     }
@@ -356,9 +354,8 @@ void AdInterface::add_user_to_group(const QString &group_dn, const QString &user
 }
 
 void AdInterface::rename(const QString &dn, const QString &new_name) {
-    // Load attributes so they are available for objects
-    // connecting to signals
-    // NOTE: have to do this because operation
+    // Load attributes so they are available for objects connecting to signals
+    // NOTE: have to do this before operation
     if (!attributes_loaded(dn)) {
         load_attributes(dn);
     }

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -495,8 +495,6 @@ void AdInterface::update_cache(const QString &old_dn, const QString &new_dn) {
 
     // Update attributes of entries related to this entry
     QSet<QString> updated_entries;
-
-    // Iterate through all attributes and update if needed
     for (const QString &dn : attributes_map.keys()) {
         for (auto &values : attributes_map[dn]) {
             const int old_dn_i = values.indexOf(old_dn);

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -523,7 +523,7 @@ void AdInterface::update_related_entries(const QString &old_dn, const QString &n
     const bool deleted = (old_dn != "" && new_dn == "");
     const bool changed = (old_dn != "" && new_dn != "" && old_dn != new_dn);
 
-    QList<QString> updated_entries;
+    QSet<QString> updated_entries;
 
     // TODO: update state connected through policy linkage
 
@@ -539,10 +539,10 @@ void AdInterface::update_related_entries(const QString &old_dn, const QString &n
         if (attributes_loaded(group)) {
             if (deleted) {
                 remove_attribute_internal(group, "member", old_dn);
-                updated_entries.append(group);
+                updated_entries.insert(group);
             } else if (changed) {
                 replace_attribute_internal(group, "member", old_dn, new_dn);
-                updated_entries.append(group);
+                updated_entries.insert(group);
             }
         }
     }
@@ -554,10 +554,10 @@ void AdInterface::update_related_entries(const QString &old_dn, const QString &n
         if (attributes_loaded(member)) {
             if (deleted) {
                 remove_attribute_internal(member, "memberOf", old_dn);
-                updated_entries.append(member);
+                updated_entries.insert(member);
             } else if (changed) {
                 replace_attribute_internal(member, "memberOf", old_dn, new_dn);
-                updated_entries.append(member);
+                updated_entries.insert(member);
             }
         }
     }

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -311,6 +311,13 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
     }
 }
 
+void AdInterface::add_attribute_internal(const QString &dn, const QString &attribute, const QString &dn) {
+    // TODO: insert attributes near other attributes with same name
+    attributes_map[dn][attribute].append(dn);
+    
+    emit attributes_changed(dn);
+}
+
 void AdInterface::add_user_to_group(const QString &group_dn, const QString &user_dn) {
     int result = AD_INVALID_DN;
 
@@ -324,18 +331,11 @@ void AdInterface::add_user_to_group(const QString &group_dn, const QString &user
 
     if (result == AD_SUCCESS) {
         // Update attributes of user and group
-        // TODO: insert attributes near other attributes with same name
         if (attributes_loaded.contains(group_dn)) {
-            // Add attribute "member = user_dn" to group
-            attributes_map[group_dn]["member"].append(user_dn);
-
-            emit attributes_changed(user_dn);
+            add_attribute_internal(group_dn, "member", user_dn);
         }
         if (attributes_loaded.contains(group_dn)) {
-            // Add attribute "memberOf = group_dn" to user
-            attributes_map[user_dn]["memberOf"].append(group_dn);
-
-            emit attributes_changed(group_dn);
+            add_attribute_internal(user_dn, "memberOf", group_dn);
         }
 
         emit add_user_to_group_complete(group_dn, user_dn);

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -217,7 +217,7 @@ bool AdInterface::set_attribute(const QString &dn, const QString &attribute, con
     }
 }
 
-void AdInterface::create_entry(const QString &name, const QString &dn, NewEntryType type) {
+bool AdInterface::create_entry(const QString &name, const QString &dn, NewEntryType type) {
     int result = AD_INVALID_DN;
     
     const QByteArray name_array = name.toLatin1();
@@ -248,8 +248,12 @@ void AdInterface::create_entry(const QString &name, const QString &dn, NewEntryT
 
     if (result == AD_SUCCESS) {
         emit create_entry_complete(dn, type);
+
+        return true;
     } else {
         emit create_entry_failed(dn, type, get_error_str());
+
+        return false;
     }
 }
 

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -273,9 +273,9 @@ void AdInterface::delete_entry(const QString &dn) {
     if (result == AD_SUCCESS) {
         update_related_entries(dn, "");
         
-        unload_internal_attributes(dn);
-
         emit delete_entry_complete(dn);
+    
+        unload_internal_attributes(dn);
     } else {
         emit delete_entry_failed(dn, get_error_str());
     }
@@ -319,9 +319,9 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
 
         update_related_entries(dn, new_dn);
 
-        unload_internal_attributes(dn);
-
         emit move_complete(dn, new_container, new_dn);
+
+        unload_internal_attributes(dn);
     } else {
         emit move_failed(dn, new_container, new_dn, get_error_str());
     }
@@ -391,9 +391,9 @@ void AdInterface::rename(const QString &dn, const QString &new_name) {
 
         update_related_entries(dn, new_dn);
 
-        unload_internal_attributes(dn);
-
         emit rename_complete(dn, new_name, new_dn);
+
+        unload_internal_attributes(dn);
     } else {
         emit rename_failed(dn, new_name, new_dn, get_error_str());
     }

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -313,9 +313,11 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
 
 void AdInterface::add_attribute_internal(const QString &dn, const QString &attribute, const QString &dn) {
     // TODO: insert attributes near other attributes with same name
-    attributes_map[dn][attribute].append(dn);
-    
-    emit attributes_changed(dn);
+    if (attributes_loaded.contains(group_dn)) {
+        attributes_map[dn][attribute].append(dn);
+
+        emit attributes_changed(dn);
+    }
 }
 
 void AdInterface::add_user_to_group(const QString &group_dn, const QString &user_dn) {
@@ -331,12 +333,8 @@ void AdInterface::add_user_to_group(const QString &group_dn, const QString &user
 
     if (result == AD_SUCCESS) {
         // Update attributes of user and group
-        if (attributes_loaded.contains(group_dn)) {
-            add_attribute_internal(group_dn, "member", user_dn);
-        }
-        if (attributes_loaded.contains(group_dn)) {
-            add_attribute_internal(user_dn, "memberOf", group_dn);
-        }
+        add_attribute_internal(group_dn, "member", user_dn);
+        add_attribute_internal(user_dn, "memberOf", group_dn);
 
         emit add_user_to_group_complete(group_dn, user_dn);
     } else {

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -249,9 +249,6 @@ bool AdInterface::create_entry(const QString &name, const QString &dn, NewEntryT
     }
 
     if (result == AD_SUCCESS) {
-        // Newly created entry so load it's attributes
-        load_attributes(dn);
-
         emit create_entry_complete(dn, type);
 
         return true;

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -132,7 +132,7 @@ void AdInterface::load_attributes(const QString &dn) {
         }
         free(attributes_raw);
 
-        attributes_loaded_set.insert(dn);
+        attributes_loaded.insert(dn);
 
         emit load_attributes_complete(dn);
     } else if (connection->get_errcode() != AD_SUCCESS) {
@@ -141,7 +141,7 @@ void AdInterface::load_attributes(const QString &dn) {
 }
 
 QMap<QString, QList<QString>> AdInterface::get_attributes(const QString &dn) {
-    if (!attributes_loaded(dn)) {
+    if (!attributes_loaded.contains(dn)) {
         load_attributes(dn);
     }
 
@@ -318,13 +318,13 @@ void AdInterface::add_user_to_group(const QString &group_dn, const QString &user
     if (result == AD_SUCCESS) {
         // Update attributes of user and group
         // TODO: insert attributes near other attributes with same name
-        if (attributes_loaded(group_dn)) {
+        if (attributes_loaded.contains(group_dn)) {
             // Add attribute "member = user_dn" to group
             attributes_map[group_dn]["member"].append(user_dn);
 
             emit attributes_changed(user_dn);
         }
-        if (attributes_loaded(group_dn)) {
+        if (attributes_loaded.contains(group_dn)) {
             // Add attribute "memberOf = group_dn" to user
             attributes_map[user_dn]["memberOf"].append(group_dn);
 
@@ -468,11 +468,6 @@ void AdInterface::drop_entry(const QString &dn, const QString &target_dn) {
     }
 }
 
-bool AdInterface::attributes_loaded(const QString &dn) {
-    const bool loaded = attributes_loaded_set.contains(dn);
-    return loaded;
-}
-
 // Update all attributes that contain this dn, by deleting
 // or replacing with new one
 // LDAP database does all this on it's own so need to replicate it
@@ -482,11 +477,11 @@ void AdInterface::update_cache(const QString &old_dn, const QString &new_dn) {
     const bool changed = (old_dn != "" && new_dn != "" && old_dn != new_dn);
 
     // Update entry's attributes
-    if (attributes_loaded(old_dn)) {
+    if (attributes_loaded.contains(old_dn)) {
         if (deleted || changed) {
             // Unload attributes for old dn
             attributes_map.remove(old_dn);
-            attributes_loaded_set.remove(old_dn);
+            attributes_loaded.remove(old_dn);
         }
 
         if (changed) {

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -141,6 +141,9 @@ void AdInterface::load_attributes(const QString &dn) {
 }
 
 QMap<QString, QList<QString>> AdInterface::get_attributes(const QString &dn) {
+    // First check whether load_attributes was ever called on this dn
+    // If it hasn't, attempt to load attributes
+    // After that return whatever attributes are now loaded for this dn
     if (!attributes_loaded.contains(dn)) {
         load_attributes(dn);
     }

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -333,13 +333,14 @@ void AdInterface::add_user_to_group(const QString &group_dn, const QString &user
         // Update attributes of user and group
         if (attributes_loaded(group_dn)) {
             add_attribute_internal(group_dn, "member", user_dn);
+        
+            emit attributes_changed(user_dn);
         }
         if (attributes_loaded(group_dn)) {
             add_attribute_internal(user_dn, "memberOf", group_dn);
+        
+            emit attributes_changed(group_dn);
         }
-
-        emit attributes_changed(user_dn);
-        emit attributes_changed(group_dn);
 
         emit add_user_to_group_complete(group_dn, user_dn);
     } else {

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -125,9 +125,10 @@ signals:
 private:
     adldap::AdConnection *connection = nullptr;
     QMap<QString, QMap<QString, QList<QString>>> attributes_map;
-    QSet<QString> attributes_loaded;
+    QSet<QString> attributes_loaded_set;
 
     void load_attributes(const QString &dn);
+    bool attributes_loaded(const QString &dn);
     void unload_internal_attributes(const QString &dn);
     void add_attribute_internal(const QString &dn, const QString &attribute, const QString &value);
     void remove_attribute_internal(const QString &dn, const QString &attribute, const QString &value);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -68,7 +68,6 @@ public:
     QString get_error_str();
 
     QList<QString> load_children(const QString &dn);
-
     QMap<QString, QList<QString>> get_attributes(const QString &dn);
     QList<QString> get_attribute_multi(const QString &dn, const QString &attribute);
     QString get_attribute(const QString &dn, const QString &attribute);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -129,9 +129,6 @@ private:
     void load_attributes(const QString &dn);
     bool attributes_loaded(const QString &dn);
     void unload_internal_attributes(const QString &dn);
-    void add_attribute_internal(const QString &dn, const QString &attribute, const QString &value);
-    void remove_attribute_internal(const QString &dn, const QString &attribute, const QString &value);
-    void replace_attribute_internal(const QString &dn, const QString &attribute, const QString &old_value, const QString &new_value);
     void update_related_entries(const QString &old_dn, const QString &new_dn);
 
 }; 

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -124,10 +124,9 @@ signals:
 private:
     adldap::AdConnection *connection = nullptr;
     QMap<QString, QMap<QString, QList<QString>>> attributes_map;
-    QSet<QString> attributes_loaded_set;
+    QSet<QString> attributes_loaded;
 
     void load_attributes(const QString &dn);
-    bool attributes_loaded(const QString &dn);
     void update_cache(const QString &old_dn, const QString &new_dn);
 
 }; 

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -69,7 +69,7 @@ public:
 
     QList<QString> load_children(const QString &dn);
 
-    // These functions implicitly load attributes if haven't loaded yet
+    // These functions load attributes if haven't loaded yet
     QMap<QString, QList<QString>> get_attributes(const QString &dn);
     QList<QString> get_attribute_multi(const QString &dn, const QString &attribute);
     QString get_attribute(const QString &dn, const QString &attribute);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -68,10 +68,18 @@ public:
     QString get_error_str();
 
     QList<QString> load_children(const QString &dn);
+
+    // These functions implicitly load attributes if haven't loaded yet
     QMap<QString, QList<QString>> get_attributes(const QString &dn);
     QList<QString> get_attribute_multi(const QString &dn, const QString &attribute);
     QString get_attribute(const QString &dn, const QString &attribute);
     bool attribute_value_exists(const QString &dn, const QString &attribute, const QString &value);
+    bool is_user(const QString &dn);
+    bool is_group(const QString &dn);
+    bool is_container(const QString &dn);
+    bool is_ou(const QString &dn);
+    bool is_policy(const QString &dn);
+    bool is_container_like(const QString &dn);
 
     bool set_attribute(const QString &dn, const QString &attribute, const QString &value);
     bool create_entry(const QString &name, const QString &dn, NewEntryType type);
@@ -79,13 +87,6 @@ public:
     void move(const QString &dn, const QString &new_container);
     void add_user_to_group(const QString &group_dn, const QString &user_dn);
     void rename(const QString &dn, const QString &new_name);
-
-    bool is_user(const QString &dn);
-    bool is_group(const QString &dn);
-    bool is_container(const QString &dn);
-    bool is_ou(const QString &dn);
-    bool is_policy(const QString &dn);
-    bool is_container_like(const QString &dn);
 
     bool can_drop_entry(const QString &dn, const QString &target_dn);
     void drop_entry(const QString &dn, const QString &target_dn);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -128,7 +128,7 @@ private:
 
     void load_attributes(const QString &dn);
     void update_cache(const QString &old_dn, const QString &new_dn);
-    void add_attribute_internal(const QString &dn, const QString &attribute, const QString &dn);
+    void add_attribute_internal(const QString &dn, const QString &attribute, const QString &value);
 
 }; 
 

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -128,6 +128,7 @@ private:
 
     void load_attributes(const QString &dn);
     void update_cache(const QString &old_dn, const QString &new_dn);
+    void add_attribute_internal(const QString &dn, const QString &attribute, const QString &dn);
 
 }; 
 

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -117,13 +117,21 @@ signals:
     void rename_complete(const QString &dn, const QString &new_name, const QString &new_dn);
     void rename_failed(const QString &dn, const QString &new_name, const QString &new_dn, const QString &error_str);
 
+    void attribute_added(const QString &dn, const QString &attribute, const QString &value);
+    void attribute_removed(const QString &dn, const QString &attribute, const QString &value);
+    void attribute_replaced(const QString &dn, const QString &attribute, const QString &old_value, const QString &new_value);
+
+
 private:
     adldap::AdConnection *connection = nullptr;
     QMap<QString, QMap<QString, QList<QString>>> attributes_map;
     QSet<QString> attributes_loaded;
 
     void load_attributes(const QString &dn);
-    void update_related_entries(const QString &dn);
+    void add_attribute_internal(const QString &dn, const QString &attribute, const QString &value);
+    void remove_attribute_internal(const QString &dn, const QString &attribute, const QString &value);
+    void replace_attribute_internal(const QString &dn, const QString &attribute, const QString &old_value, const QString &new_value);
+    void change_dn_internal(const QString &old_dn, const QString &new_dn);
 
 }; 
 

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -128,8 +128,7 @@ private:
 
     void load_attributes(const QString &dn);
     bool attributes_loaded(const QString &dn);
-    void unload_internal_attributes(const QString &dn);
-    void update_related_entries(const QString &old_dn, const QString &new_dn);
+    void update_cache(const QString &old_dn, const QString &new_dn);
 
 }; 
 

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -118,9 +118,7 @@ signals:
     void rename_complete(const QString &dn, const QString &new_name, const QString &new_dn);
     void rename_failed(const QString &dn, const QString &new_name, const QString &new_dn, const QString &error_str);
 
-    void attribute_added(const QString &dn, const QString &attribute, const QString &value);
-    void attribute_removed(const QString &dn, const QString &attribute, const QString &value);
-    void attribute_replaced(const QString &dn, const QString &attribute, const QString &old_value, const QString &new_value);
+    void attributes_changed(const QString &dn);
 
 
 private:

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -82,7 +82,7 @@ public:
     bool is_container_like(const QString &dn);
 
     bool set_attribute(const QString &dn, const QString &attribute, const QString &value);
-    bool create_entry(const QString &name, const QString &dn, NewEntryType type);
+    void create_entry(const QString &name, const QString &dn, NewEntryType type);
     void delete_entry(const QString &dn);
     void move(const QString &dn, const QString &new_container);
     void add_user_to_group(const QString &group_dn, const QString &user_dn);
@@ -118,8 +118,8 @@ signals:
     void rename_complete(const QString &dn, const QString &new_name, const QString &new_dn);
     void rename_failed(const QString &dn, const QString &new_name, const QString &new_dn, const QString &error_str);
 
+    void dn_changed(const QString &dn, const QString &new_dn);
     void attributes_changed(const QString &dn);
-
 
 private:
     adldap::AdConnection *connection = nullptr;

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -69,17 +69,10 @@ public:
 
     QList<QString> load_children(const QString &dn);
 
-    // These functions load attributes if haven't loaded yet
     QMap<QString, QList<QString>> get_attributes(const QString &dn);
     QList<QString> get_attribute_multi(const QString &dn, const QString &attribute);
     QString get_attribute(const QString &dn, const QString &attribute);
     bool attribute_value_exists(const QString &dn, const QString &attribute, const QString &value);
-    bool is_user(const QString &dn);
-    bool is_group(const QString &dn);
-    bool is_container(const QString &dn);
-    bool is_ou(const QString &dn);
-    bool is_policy(const QString &dn);
-    bool is_container_like(const QString &dn);
 
     bool set_attribute(const QString &dn, const QString &attribute, const QString &value);
     bool create_entry(const QString &name, const QString &dn, NewEntryType type);
@@ -87,6 +80,13 @@ public:
     void move(const QString &dn, const QString &new_container);
     void add_user_to_group(const QString &group_dn, const QString &user_dn);
     void rename(const QString &dn, const QString &new_name);
+
+    bool is_user(const QString &dn);
+    bool is_group(const QString &dn);
+    bool is_container(const QString &dn);
+    bool is_ou(const QString &dn);
+    bool is_policy(const QString &dn);
+    bool is_container_like(const QString &dn);
 
     bool can_drop_entry(const QString &dn, const QString &target_dn);
     void drop_entry(const QString &dn, const QString &target_dn);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -82,7 +82,7 @@ public:
     bool is_container_like(const QString &dn);
 
     bool set_attribute(const QString &dn, const QString &attribute, const QString &value);
-    void create_entry(const QString &name, const QString &dn, NewEntryType type);
+    bool create_entry(const QString &name, const QString &dn, NewEntryType type);
     void delete_entry(const QString &dn);
     void move(const QString &dn, const QString &new_container);
     void add_user_to_group(const QString &group_dn, const QString &user_dn);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -128,10 +128,11 @@ private:
     QSet<QString> attributes_loaded;
 
     void load_attributes(const QString &dn);
+    void unload_internal_attributes(const QString &dn);
     void add_attribute_internal(const QString &dn, const QString &attribute, const QString &value);
     void remove_attribute_internal(const QString &dn, const QString &attribute, const QString &value);
     void replace_attribute_internal(const QString &dn, const QString &attribute, const QString &old_value, const QString &new_value);
-    void change_dn_internal(const QString &old_dn, const QString &new_dn);
+    void update_related_entries(const QString &old_dn, const QString &new_dn);
 
 }; 
 

--- a/src/ad_model.cpp
+++ b/src/ad_model.cpp
@@ -42,11 +42,11 @@ AdModel::AdModel(QObject *parent)
         AD(), &AdInterface::delete_entry_complete,
         this, &AdModel::on_delete_entry_complete);
     connect(
-        AD(), &AdInterface::dn_changed,
-        this, &AdModel::on_dn_changed);
-    connect(
         AD(), &AdInterface::create_entry_complete,
         this, &AdModel::on_create_entry_complete);
+    connect(
+        AD(), &AdInterface::dn_changed,
+        this, &AdModel::on_dn_changed);
     connect(
         AD(), &AdInterface::attributes_changed,
         this, &AdModel::on_attributes_changed);
@@ -125,7 +125,8 @@ void AdModel::on_dn_changed(const QString &dn, const QString &new_dn) {
     // been expanded/fetched
     // NOTE: loading if parent hasn't been fetched will
     // create a duplicate
-    QList<QStandardItem *> parent_items = findItems(new_container, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
+    const QString new_parent = extract_parent_dn_from_dn(new_dn);
+    QList<QStandardItem *> parent_items = findItems(new_parent, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
     if (parent_items.size() > 0) {
         QStandardItem *parent_dn_item = parent_items[0];
         QModelIndex parent_dn_index = parent_dn_item->index();

--- a/src/ad_model.cpp
+++ b/src/ad_model.cpp
@@ -42,17 +42,14 @@ AdModel::AdModel(QObject *parent)
         AD(), &AdInterface::delete_entry_complete,
         this, &AdModel::on_delete_entry_complete);
     connect(
-        AD(), &AdInterface::move_complete,
-        this, &AdModel::on_move_complete);
+        AD(), &AdInterface::dn_changed,
+        this, &AdModel::on_dn_changed);
     connect(
         AD(), &AdInterface::create_entry_complete,
         this, &AdModel::on_create_entry_complete);
     connect(
         AD(), &AdInterface::attributes_changed,
         this, &AdModel::on_attributes_changed);
-    connect(
-        AD(), &AdInterface::rename_complete,
-        this, &AdModel::on_rename_complete);
 }
 
 bool AdModel::canFetchMore(const QModelIndex &parent) const {
@@ -114,7 +111,7 @@ void AdModel::on_delete_entry_complete(const QString &dn) {
     }
 }
 
-void AdModel::on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn) {
+void AdModel::on_dn_changed(const QString &dn, const QString &new_dn) {
     // Remove old entry from model
     QList<QStandardItem *> old_items = findItems(dn, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
     if (old_items.size() > 0) {
@@ -188,22 +185,6 @@ void AdModel::on_attributes_changed(const QString &dn) {
     }
 
     load_row(row, dn);
-}
-
-void AdModel::on_rename_complete(const QString &dn, const QString &new_name, const QString &new_dn) {
-    // Find row still attached to old dn
-    QList<QStandardItem *> items = findItems(dn, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
-
-    if (items.size() == 0) {
-        return;
-    }
-    
-    // Change dn of row to new dn
-    QStandardItem *dn_item = items[0];
-    dn_item->setText(new_dn);
-
-    // Reload attributes
-    on_attributes_changed(new_dn);
 }
 
 // Load data into row of items based on entry attributes

--- a/src/ad_model.cpp
+++ b/src/ad_model.cpp
@@ -48,8 +48,8 @@ AdModel::AdModel(QObject *parent)
         AD(), &AdInterface::create_entry_complete,
         this, &AdModel::on_create_entry_complete);
     connect(
-        AD(), &AdInterface::load_attributes_complete,
-        this, &AdModel::on_load_attributes_complete);
+        AD(), &AdInterface::attributes_changed,
+        this, &AdModel::on_attributes_changed);
     connect(
         AD(), &AdInterface::rename_complete,
         this, &AdModel::on_rename_complete);
@@ -161,7 +161,7 @@ void AdModel::on_create_entry_complete(const QString &dn, NewEntryType type) {
     }
 }
 
-void AdModel::on_load_attributes_complete(const QString &dn) {
+void AdModel::on_attributes_changed(const QString &dn) {
     // Compose row based on dn
     QList<QStandardItem *> items = findItems(dn, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
 
@@ -203,7 +203,7 @@ void AdModel::on_rename_complete(const QString &dn, const QString &new_name, con
     dn_item->setText(new_dn);
 
     // Reload attributes
-    on_load_attributes_complete(new_dn);
+    on_attributes_changed(new_dn);
 }
 
 // Load data into row of items based on entry attributes

--- a/src/ad_model.h
+++ b/src/ad_model.h
@@ -54,9 +54,9 @@ public:
 
 private slots:
     void on_ad_interface_login_complete(const QString &search_base, const QString &head_dn);
-    void on_attributes_changed(const QString &dn);
     void on_delete_entry_complete(const QString &dn); 
-    void on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn);
+    void on_attributes_changed(const QString &dn);
+    void on_dn_changed(const QString &dn, const QString &new_dn);
     void on_create_entry_complete(const QString &dn, NewEntryType type); 
 private:
     void set_headers();

--- a/src/ad_model.h
+++ b/src/ad_model.h
@@ -54,7 +54,7 @@ public:
 
 private slots:
     void on_ad_interface_login_complete(const QString &search_base, const QString &head_dn);
-    void on_load_attributes_complete(const QString &dn);
+    void on_attributes_changed(const QString &dn);
     void on_delete_entry_complete(const QString &dn); 
     void on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn);
     void on_create_entry_complete(const QString &dn, NewEntryType type); 

--- a/src/ad_model.h
+++ b/src/ad_model.h
@@ -58,8 +58,6 @@ private slots:
     void on_delete_entry_complete(const QString &dn); 
     void on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn);
     void on_create_entry_complete(const QString &dn, NewEntryType type); 
-    void on_rename_complete(const QString &dn, const QString &new_name, const QString &new_dn); 
-
 private:
     void set_headers();
 

--- a/src/details_widget.cpp
+++ b/src/details_widget.cpp
@@ -105,7 +105,7 @@ void DetailsWidget::on_attributes_changed(const QString &dn) {
     }
 }
 
-void DetailsWidget::on_dn_changed(const QString &dn, const QString &new_name, const QString &new_dn) {
+void DetailsWidget::on_dn_changed(const QString &dn, const QString &new_dn) {
     if (target_dn == dn) {
         change_target(new_dn);
     }

--- a/src/details_widget.cpp
+++ b/src/details_widget.cpp
@@ -50,8 +50,8 @@ DetailsWidget::DetailsWidget(MembersWidget *members_widget_)
         AD(), &AdInterface::move_complete,
         this, &DetailsWidget::on_move_complete);
     connect(
-        AD(), &AdInterface::load_attributes_complete,
-        this, &DetailsWidget::on_load_attributes_complete);
+        AD(), &AdInterface::attributes_changed,
+        this, &DetailsWidget::on_attributes_changed);
     connect(
         AD(), &AdInterface::rename_complete,
         this, &DetailsWidget::on_rename_complete);
@@ -108,7 +108,7 @@ void DetailsWidget::on_move_complete(const QString &dn, const QString &new_conta
     }
 }
 
-void DetailsWidget::on_load_attributes_complete(const QString &dn) {
+void DetailsWidget::on_attributes_changed(const QString &dn) {
     // Reload entry since attributes were updated
     if (target_dn == dn) {
         change_target(dn);

--- a/src/details_widget.cpp
+++ b/src/details_widget.cpp
@@ -47,14 +47,11 @@ DetailsWidget::DetailsWidget(MembersWidget *members_widget_)
         AD(), &AdInterface::delete_entry_complete,
         this, &DetailsWidget::on_delete_entry_complete);
     connect(
-        AD(), &AdInterface::move_complete,
-        this, &DetailsWidget::on_move_complete);
-    connect(
         AD(), &AdInterface::attributes_changed,
         this, &DetailsWidget::on_attributes_changed);
     connect(
-        AD(), &AdInterface::rename_complete,
-        this, &DetailsWidget::on_rename_complete);
+        AD(), &AdInterface::dn_changed,
+        this, &DetailsWidget::on_dn_changed);
 
     change_target("");
 };
@@ -101,13 +98,6 @@ void DetailsWidget::on_delete_entry_complete(const QString &dn) {
     }
 }
 
-void DetailsWidget::on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn) {
-    // Switch to the entry at new dn (entry stays the same)
-    if (target_dn == dn) {
-        change_target(new_dn);
-    }
-}
-
 void DetailsWidget::on_attributes_changed(const QString &dn) {
     // Reload entry since attributes were updated
     if (target_dn == dn) {
@@ -115,7 +105,7 @@ void DetailsWidget::on_attributes_changed(const QString &dn) {
     }
 }
 
-void DetailsWidget::on_rename_complete(const QString &dn, const QString &new_name, const QString &new_dn) {
+void DetailsWidget::on_dn_changed(const QString &dn, const QString &new_name, const QString &new_dn) {
     if (target_dn == dn) {
         change_target(new_dn);
     }

--- a/src/details_widget.h
+++ b/src/details_widget.h
@@ -44,9 +44,8 @@ public slots:
 private slots:
     void on_ad_interface_login_complete(const QString &search_base, const QString &head_dn);
     void on_delete_entry_complete(const QString &dn); 
-    void on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn); 
+    void on_dn_changed(const QString &dn, const QString &new_container, const QString &new_dn); 
     void on_attributes_changed(const QString &dn);
-    void on_rename_complete(const QString &dn, const QString &new_name, const QString &new_dn);
 
 private:
     AttributesModel *attributes_model = nullptr;

--- a/src/details_widget.h
+++ b/src/details_widget.h
@@ -44,7 +44,7 @@ public slots:
 private slots:
     void on_ad_interface_login_complete(const QString &search_base, const QString &head_dn);
     void on_delete_entry_complete(const QString &dn); 
-    void on_dn_changed(const QString &dn, const QString &new_container, const QString &new_dn); 
+    void on_dn_changed(const QString &dn, const QString &new_dn); 
     void on_attributes_changed(const QString &dn);
 
 private:

--- a/src/details_widget.h
+++ b/src/details_widget.h
@@ -45,7 +45,7 @@ private slots:
     void on_ad_interface_login_complete(const QString &search_base, const QString &head_dn);
     void on_delete_entry_complete(const QString &dn); 
     void on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn); 
-    void on_load_attributes_complete(const QString &dn);
+    void on_attributes_changed(const QString &dn);
     void on_rename_complete(const QString &dn, const QString &new_name, const QString &new_dn);
 
 private:

--- a/src/members_model.cpp
+++ b/src/members_model.cpp
@@ -27,10 +27,6 @@ MembersModel::MembersModel(QObject *parent)
 {
     setHorizontalHeaderItem(Column::Name, new QStandardItem("Name"));
     setHorizontalHeaderItem(Column::DN, new QStandardItem("DN"));
-
-    connect(
-        AD(), &AdInterface::move_complete,
-        this, &MembersModel::on_move_complete);
 }
 
 void MembersModel::change_target(const QString &new_target_dn) {
@@ -63,15 +59,5 @@ QString MembersModel::get_dn_from_index(const QModelIndex &index) const {
         return target_dn;
     } else {
         return EntryModel::get_dn_from_index(index);
-    }
-}
-
-void MembersModel::on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn) {
-    // If entry is in members model, need to update it's dn
-    QList<QStandardItem *> items = findItems(dn, Qt::MatchExactly | Qt::MatchRecursive, Column::DN);
-
-    if (items.size() > 0) {
-        QStandardItem *dn_item = items[Column::DN];
-        dn_item->setText(new_dn);
     }
 }

--- a/src/members_model.h
+++ b/src/members_model.h
@@ -41,9 +41,6 @@ public:
 
     void change_target(const QString &new_target_dn);
 
-private slots:
-    void on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn);
-
 private:
     QString target_dn;
 


### PR DESCRIPTION
Add AdInterface::update_cache() to update attributes cache in AdInterface after AD operations. Haven't yet implemented handling indirect changes caused by moving containers/OU's.

Remove excessive load_attributes() calls. Each load_attributes() call makes an LDAP request AND emits a load_attributes_complete() so they are costly.

Instead update attributes internally. After all updates are done emit attributes_changed() signals for all updated entries.

Add dn_changed() signal as a better replacement for rename/move_complete() signals.
Add attributes_changed() signal.

NOTE: for now iterate through all entries, can optimize later using a hashtable