### PR TITLE
Update cache

### DIFF
--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -365,7 +365,7 @@ void AdInterface::rename(const QString &dn, const QString &new_name) {
         update_cache(dn, new_dn);
 
         emit dn_changed(dn, new_dn);
-        emit attributes_changed(dn);
+        emit attributes_changed(new_dn);
         emit rename_complete(dn, new_name, new_dn);
     } else {
         emit rename_failed(dn, new_name, new_dn, get_error_str());

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -305,6 +305,7 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
     if (result == AD_SUCCESS) {
         update_cache(dn, "");
 
+        emit dn_changed(dn, new_dn);
         emit move_complete(dn, new_container, new_dn);
     } else {
         emit move_failed(dn, new_container, new_dn, get_error_str());
@@ -363,6 +364,7 @@ void AdInterface::rename(const QString &dn, const QString &new_name) {
     if (result == AD_SUCCESS) {
         update_cache(dn, "");
 
+        emit dn_changed(dn, new_dn);
         emit attributes_changed(dn);
         emit rename_complete(dn, new_name, new_dn);
     } else {

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -305,7 +305,6 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
     if (result == AD_SUCCESS) {
         update_cache(dn, new_dn);
 
-        emit dn_changed(dn, new_dn);
         emit move_complete(dn, new_container, new_dn);
     } else {
         emit move_failed(dn, new_container, new_dn, get_error_str());
@@ -364,8 +363,6 @@ void AdInterface::rename(const QString &dn, const QString &new_name) {
     if (result == AD_SUCCESS) {
         update_cache(dn, new_dn);
 
-        emit dn_changed(dn, new_dn);
-        emit attributes_changed(new_dn);
         emit rename_complete(dn, new_name, new_dn);
     } else {
         emit rename_failed(dn, new_name, new_dn, get_error_str());
@@ -482,6 +479,9 @@ void AdInterface::update_cache(const QString &old_dn, const QString &new_dn) {
 
         if (changed) {
             load_attributes(new_dn);
+
+            emit dn_changed(old_dn, new_dn);
+            emit attributes_changed(new_dn);
         }
     }
 

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -303,7 +303,7 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
     }
     
     if (result == AD_SUCCESS) {
-        update_cache(dn, "");
+        update_cache(dn, new_dn);
 
         emit dn_changed(dn, new_dn);
         emit move_complete(dn, new_container, new_dn);

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -362,7 +362,7 @@ void AdInterface::rename(const QString &dn, const QString &new_name) {
     }
 
     if (result == AD_SUCCESS) {
-        update_cache(dn, "");
+        update_cache(dn, new_dn);
 
         emit dn_changed(dn, new_dn);
         emit attributes_changed(dn);

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -322,10 +322,9 @@ void AdInterface::add_user_to_group(const QString &group_dn, const QString &user
     result = connection->group_add_user(group_dn_cstr, user_dn_cstr);
 
     if (result == AD_SUCCESS) {
-        // Reload attributes of group and user because group
-        // operations affect attributes of both
-        load_attributes(group_dn);
-        load_attributes(user_dn);
+        // Update attributes of user and group
+        add_attribute_internal(group_dn, "member", user_dn);
+        add_attribute_internal(user_dn, "memberOf", group_dn);
 
         emit add_user_to_group_complete(group_dn, user_dn);
     } else {
@@ -498,6 +497,12 @@ void AdInterface::update_cache(const QString &old_dn, const QString &new_dn) {
     }
 }
 
+void AdInterface::add_attribute_internal(const QString &dn, const QString &attribute, const QString &value) {
+    // TODO: insert attributes near other attributes with same name
+    if (attributes_loaded.contains(dn)) {
+        attributes_map[dn][attribute].append(value);
+    }
+}
 
 AdInterface *AD() {
     ADMC *app = qobject_cast<ADMC *>(qApp);

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -257,28 +257,6 @@ bool AdInterface::create_entry(const QString &name, const QString &dn, NewEntryT
     }
 }
 
-// Update all entries that are related to this one through
-// membership
-void AdInterface::update_related_entries(const QString &dn) {
-    // Update all groups that have this entry as member
-    QList<QString> groups = get_attribute_multi(dn, "memberOf");
-    for (auto group : groups) {
-        // Only reload if loaded already
-        if (attributes_map.contains(group)) {
-            load_attributes(group);
-        }
-    }
-
-    // Update all entries that are members of this group
-    QList<QString> members = get_attribute_multi(dn, "member");
-    for (auto member : members) {
-        // Only reload if loaded already
-        if (attributes_map.contains(member)) {
-            load_attributes(member);
-        }
-    }
-}
-
 void AdInterface::delete_entry(const QString &dn) {
     int result = AD_INVALID_DN;
 
@@ -288,10 +266,7 @@ void AdInterface::delete_entry(const QString &dn) {
     result = connection->object_delete(dn_cstr);
 
     if (result == AD_SUCCESS) {
-        update_related_entries(dn);
-
-        attributes_map.remove(dn);
-        attributes_loaded.remove(dn);
+        update_cache(dn, "");
 
         emit delete_entry_complete(dn);
     } else {
@@ -327,12 +302,7 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
     }
     
     if (result == AD_SUCCESS) {
-        // Unload attributes at old dn
-        attributes_map.remove(dn);
-        attributes_loaded.remove(dn);
-
-        load_attributes(new_dn);
-        update_related_entries(new_dn);
+        update_cache(dn, "");
 
         emit move_complete(dn, new_container, new_dn);
     } else {
@@ -391,8 +361,7 @@ void AdInterface::rename(const QString &dn, const QString &new_name) {
     }
 
     if (result == AD_SUCCESS) {
-        load_attributes(new_dn);
-        update_related_entries(new_dn);
+        update_cache(dn, "");
 
         emit rename_complete(dn, new_name, new_dn);
     } else {
@@ -492,6 +461,43 @@ void AdInterface::drop_entry(const QString &dn, const QString &target_dn) {
         }
     }
 }
+
+// Update cache for entry and all related entries after a DN change
+// LDAP database does this internally so need to replicate it
+// NOTE: if entry was deleted, new_dn should be ""
+void AdInterface::update_cache(const QString &old_dn, const QString &new_dn) {
+    const bool deleted = (old_dn != "" && new_dn == "");
+    const bool changed = (old_dn != "" && new_dn != "" && old_dn != new_dn);
+
+    // Update entry's attributes
+    if (attributes_loaded.contains(old_dn)) {
+        if (deleted || changed) {
+            // Unload old attributes
+            attributes_map.remove(old_dn);
+            attributes_loaded.remove(old_dn);
+        }
+
+        if (changed) {
+            load_attributes(new_dn);
+        }
+    }
+
+    // Update attributes of entries related to this entry
+    for (const QString &dn : attributes_map.keys()) {
+        for (auto &values : attributes_map[dn]) {
+            const int old_dn_i = values.indexOf(old_dn);
+
+            if (old_dn_i != -1) {
+                if (deleted) {
+                    values.removeAt(old_dn_i);
+                } else if (changed) {
+                    values.replace(old_dn_i, new_dn);
+                }
+            }
+        }
+    }
+}
+
 
 AdInterface *AD() {
     ADMC *app = qobject_cast<ADMC *>(qApp);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -124,6 +124,7 @@ private:
 
     void load_attributes(const QString &dn);
     void update_cache(const QString &old_dn, const QString &new_dn);
+    void add_attribute_internal(const QString &dn, const QString &attribute, const QString &value);
 
 }; 
 

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -117,6 +117,8 @@ signals:
     void rename_complete(const QString &dn, const QString &new_name, const QString &new_dn);
     void rename_failed(const QString &dn, const QString &new_name, const QString &new_dn, const QString &error_str);
 
+    void attributes_changed(const QString &dn);
+
 private:
     adldap::AdConnection *connection = nullptr;
     QMap<QString, QMap<QString, QList<QString>>> attributes_map;

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -117,6 +117,7 @@ signals:
     void rename_complete(const QString &dn, const QString &new_name, const QString &new_dn);
     void rename_failed(const QString &dn, const QString &new_name, const QString &new_dn, const QString &error_str);
 
+    void dn_changed(const QString &old_dn, const QString &new_dn);
     void attributes_changed(const QString &dn);
 
 private:

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -123,7 +123,7 @@ private:
     QSet<QString> attributes_loaded;
 
     void load_attributes(const QString &dn);
-    void update_related_entries(const QString &dn);
+    void update_cache(const QString &old_dn, const QString &new_dn);
 
 }; 
 

--- a/src/ad_model.cpp
+++ b/src/ad_model.cpp
@@ -111,9 +111,9 @@ void AdModel::on_delete_entry_complete(const QString &dn) {
     }
 }
 
-void AdModel::on_dn_changed(const QString &dn, const QString &new_dn) {
+void AdModel::on_dn_changed(const QString &old_dn, const QString &new_dn) {
     // Remove old entry from model
-    QList<QStandardItem *> old_items = findItems(dn, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
+    QList<QStandardItem *> old_items = findItems(old_dn, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
     if (old_items.size() > 0) {
         QStandardItem *dn_item = old_items[0];
         QModelIndex dn_index = dn_item->index();

--- a/src/ad_model.cpp
+++ b/src/ad_model.cpp
@@ -42,17 +42,14 @@ AdModel::AdModel(QObject *parent)
         AD(), &AdInterface::delete_entry_complete,
         this, &AdModel::on_delete_entry_complete);
     connect(
-        AD(), &AdInterface::move_complete,
-        this, &AdModel::on_move_complete);
+        AD(), &AdInterface::dn_changed,
+        this, &AdModel::on_dn_changed);
     connect(
         AD(), &AdInterface::create_entry_complete,
         this, &AdModel::on_create_entry_complete);
     connect(
-        AD(), &AdInterface::load_attributes_complete,
-        this, &AdModel::on_load_attributes_complete);
-    connect(
-        AD(), &AdInterface::rename_complete,
-        this, &AdModel::on_rename_complete);
+        AD(), &AdInterface::attributes_changed,
+        this, &AdModel::on_attributes_changed);
 }
 
 bool AdModel::canFetchMore(const QModelIndex &parent) const {
@@ -114,7 +111,7 @@ void AdModel::on_delete_entry_complete(const QString &dn) {
     }
 }
 
-void AdModel::on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn) {
+void AdModel::on_dn_changed(const QString &dn, const QString &new_dn) {
     // Remove old entry from model
     QList<QStandardItem *> old_items = findItems(dn, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
     if (old_items.size() > 0) {
@@ -128,7 +125,8 @@ void AdModel::on_move_complete(const QString &dn, const QString &new_container, 
     // been expanded/fetched
     // NOTE: loading if parent hasn't been fetched will
     // create a duplicate
-    QList<QStandardItem *> parent_items = findItems(new_container, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
+    const QString new_parent = extract_parent_dn_from_dn(new_dn);
+    QList<QStandardItem *> parent_items = findItems(new_parent, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
     if (parent_items.size() > 0) {
         QStandardItem *parent_dn_item = parent_items[0];
         QModelIndex parent_dn_index = parent_dn_item->index();
@@ -161,7 +159,7 @@ void AdModel::on_create_entry_complete(const QString &dn, NewEntryType type) {
     }
 }
 
-void AdModel::on_load_attributes_complete(const QString &dn) {
+void AdModel::on_attributes_changed(const QString &dn) {
     // Compose row based on dn
     QList<QStandardItem *> items = findItems(dn, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
 
@@ -188,22 +186,6 @@ void AdModel::on_load_attributes_complete(const QString &dn) {
     }
 
     load_row(row, dn);
-}
-
-void AdModel::on_rename_complete(const QString &dn, const QString &new_name, const QString &new_dn) {
-    // Find row still attached to old dn
-    QList<QStandardItem *> items = findItems(dn, Qt::MatchExactly | Qt::MatchRecursive, AdModel::Column::DN);
-
-    if (items.size() == 0) {
-        return;
-    }
-    
-    // Change dn of row to new dn
-    QStandardItem *dn_item = items[0];
-    dn_item->setText(new_dn);
-
-    // Reload attributes
-    on_load_attributes_complete(new_dn);
 }
 
 // Load data into row of items based on entry attributes

--- a/src/ad_model.h
+++ b/src/ad_model.h
@@ -56,7 +56,7 @@ private slots:
     void on_ad_interface_login_complete(const QString &search_base, const QString &head_dn);
     void on_attributes_changed(const QString &dn);
     void on_delete_entry_complete(const QString &dn); 
-    void on_dn_changed(const QString &dn, const QString &new_dn);
+    void on_dn_changed(const QString &old_dn, const QString &new_dn);
     void on_create_entry_complete(const QString &dn, NewEntryType type); 
 
 private:

--- a/src/ad_model.h
+++ b/src/ad_model.h
@@ -54,11 +54,10 @@ public:
 
 private slots:
     void on_ad_interface_login_complete(const QString &search_base, const QString &head_dn);
-    void on_load_attributes_complete(const QString &dn);
+    void on_attributes_changed(const QString &dn);
     void on_delete_entry_complete(const QString &dn); 
-    void on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn);
+    void on_dn_changed(const QString &dn, const QString &new_dn);
     void on_create_entry_complete(const QString &dn, NewEntryType type); 
-    void on_rename_complete(const QString &dn, const QString &new_name, const QString &new_dn); 
 
 private:
     void set_headers();

--- a/src/details_widget.cpp
+++ b/src/details_widget.cpp
@@ -98,9 +98,9 @@ void DetailsWidget::on_delete_entry_complete(const QString &dn) {
     }
 }
 
-void DetailsWidget::on_dn_changed(const QString &dn, const QString &new_dn) {
+void DetailsWidget::on_dn_changed(const QString &old_dn, const QString &new_dn) {
     // Switch to the entry at new dn (entry stays the same)
-    if (target_dn == dn) {
+    if (target_dn == old_dn) {
         change_target(new_dn);
     }
 }

--- a/src/details_widget.cpp
+++ b/src/details_widget.cpp
@@ -47,14 +47,11 @@ DetailsWidget::DetailsWidget(MembersWidget *members_widget_)
         AD(), &AdInterface::delete_entry_complete,
         this, &DetailsWidget::on_delete_entry_complete);
     connect(
-        AD(), &AdInterface::move_complete,
-        this, &DetailsWidget::on_move_complete);
+        AD(), &AdInterface::dn_changed,
+        this, &DetailsWidget::on_dn_changed);
     connect(
-        AD(), &AdInterface::load_attributes_complete,
-        this, &DetailsWidget::on_load_attributes_complete);
-    connect(
-        AD(), &AdInterface::rename_complete,
-        this, &DetailsWidget::on_rename_complete);
+        AD(), &AdInterface::attributes_changed,
+        this, &DetailsWidget::on_attributes_changed);
 
     change_target("");
 };
@@ -101,23 +98,17 @@ void DetailsWidget::on_delete_entry_complete(const QString &dn) {
     }
 }
 
-void DetailsWidget::on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn) {
+void DetailsWidget::on_dn_changed(const QString &dn, const QString &new_dn) {
     // Switch to the entry at new dn (entry stays the same)
     if (target_dn == dn) {
         change_target(new_dn);
     }
 }
 
-void DetailsWidget::on_load_attributes_complete(const QString &dn) {
+void DetailsWidget::on_attributes_changed(const QString &dn) {
     // Reload entry since attributes were updated
     if (target_dn == dn) {
         change_target(dn);
-    }
-}
-
-void DetailsWidget::on_rename_complete(const QString &dn, const QString &new_name, const QString &new_dn) {
-    if (target_dn == dn) {
-        change_target(new_dn);
     }
 }
 

--- a/src/details_widget.h
+++ b/src/details_widget.h
@@ -44,7 +44,7 @@ public slots:
 private slots:
     void on_ad_interface_login_complete(const QString &search_base, const QString &head_dn);
     void on_delete_entry_complete(const QString &dn); 
-    void on_dn_changed(const QString &dn, const QString &new_dn); 
+    void on_dn_changed(const QString &old_dn, const QString &new_dn); 
     void on_attributes_changed(const QString &dn);
 
 private:

--- a/src/details_widget.h
+++ b/src/details_widget.h
@@ -44,9 +44,8 @@ public slots:
 private slots:
     void on_ad_interface_login_complete(const QString &search_base, const QString &head_dn);
     void on_delete_entry_complete(const QString &dn); 
-    void on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn); 
-    void on_load_attributes_complete(const QString &dn);
-    void on_rename_complete(const QString &dn, const QString &new_name, const QString &new_dn);
+    void on_dn_changed(const QString &dn, const QString &new_dn); 
+    void on_attributes_changed(const QString &dn);
 
 private:
     AttributesModel *attributes_model = nullptr;

--- a/src/members_model.cpp
+++ b/src/members_model.cpp
@@ -27,10 +27,6 @@ MembersModel::MembersModel(QObject *parent)
 {
     setHorizontalHeaderItem(Column::Name, new QStandardItem("Name"));
     setHorizontalHeaderItem(Column::DN, new QStandardItem("DN"));
-
-    connect(
-        AD(), &AdInterface::move_complete,
-        this, &MembersModel::on_move_complete);
 }
 
 void MembersModel::change_target(const QString &new_target_dn) {
@@ -63,15 +59,5 @@ QString MembersModel::get_dn_from_index(const QModelIndex &index) const {
         return target_dn;
     } else {
         return EntryModel::get_dn_from_index(index);
-    }
-}
-
-void MembersModel::on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn) {
-    // If entry is in members model, need to update it's dn
-    QList<QStandardItem *> items = findItems(dn, Qt::MatchExactly | Qt::MatchRecursive, Column::DN);
-
-    if (items.size() > 0) {
-        QStandardItem *dn_item = items[Column::DN];
-        dn_item->setText(new_dn);
     }
 }

--- a/src/members_model.h
+++ b/src/members_model.h
@@ -41,9 +41,6 @@ public:
 
     void change_target(const QString &new_target_dn);
 
-private slots:
-    void on_move_complete(const QString &dn, const QString &new_container, const QString &new_dn);
-
 private:
     QString target_dn;
 


### PR DESCRIPTION
Add AdInterface::update_cache() to update attributes cache in AdInterface after AD operations. Does what update_related_entries() did but better and more comprehensively.

Instead of doing too many load_attributes() calls update attributes internally where possible because, each load_attributes() call makes an LDAP request.

Add dn_changed() signal as a better replacement for rename/move_complete() signals.
Add attributes_changed() signal.

NOTE: for now iterate through all entries, can optimize later using a hash table
NOTE: update_cache() doesn't handle changes done by moving containers/OU's yet