### PR TITLE
Entry context menu

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ set(ADTOOL_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/src/members_widget.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/entry_model.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/src/settings.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/entry_context_menu.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/confirmation_dialog.cpp
 )
 
 add_definitions(${QT5_DEFINITIONS})

--- a/src/confirmation_dialog.cpp
+++ b/src/confirmation_dialog.cpp
@@ -17,23 +17,25 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MAIN_WINDOW_H
-#define MAIN_WINDOW_H
+#include "settings.h"
 
-#include <QMainWindow>
+#include <QString>
+#include <QMessageBox>
+#include <QAction>
 
-class MainWindow final : public QMainWindow {
-Q_OBJECT
+bool confirmation_dialog(const QString &text, QWidget *parent) {
+    const QAction *confirm_actions = SETTINGS()->confirm_actions;
+    const bool confirm_actions_checked = confirm_actions->isChecked();
+    if (!confirm_actions_checked) {
+        return true;
+    }
 
-public:
-    explicit MainWindow(const bool auto_login);
+    const QString title = "ADMC";
+    const QMessageBox::StandardButton reply = QMessageBox::question(parent, title, text, QMessageBox::Yes|QMessageBox::No);
 
-private slots:
-    void on_action_login();
-    void on_action_exit();
-
-private:
-    
-};
-
-#endif /* MAIN_WINDOW_H */
+    if (reply == QMessageBox::Yes) {
+        return true;
+    } else {
+        return false;
+    }
+}

--- a/src/confirmation_dialog.h
+++ b/src/confirmation_dialog.h
@@ -17,23 +17,12 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MAIN_WINDOW_H
-#define MAIN_WINDOW_H
+#ifndef CONFIRMATION_DIALOG_H
+#define CONFIRMATION_DIALOG_H
 
-#include <QMainWindow>
+class QString;
+class QWidget;
 
-class MainWindow final : public QMainWindow {
-Q_OBJECT
+bool confirmation_dialog(const QString &text, QWidget *parent);
 
-public:
-    explicit MainWindow(const bool auto_login);
-
-private slots:
-    void on_action_login();
-    void on_action_exit();
-
-private:
-    
-};
-
-#endif /* MAIN_WINDOW_H */
+#endif /* CONFIRMATION_DIALOG_H */

--- a/src/containers_widget.cpp
+++ b/src/containers_widget.cpp
@@ -20,12 +20,13 @@
 #include "containers_widget.h"
 #include "ad_model.h"
 #include "entry_proxy_model.h"
+#include "entry_context_menu.h"
 
 #include <QTreeView>
 #include <QLabel>
 #include <QLayout>
 
-ContainersWidget::ContainersWidget(AdModel *model, QWidget *parent)
+ContainersWidget::ContainersWidget(AdModel *model, EntryContextMenu *entry_context_menu, QWidget *parent)
 : EntryWidget(model, parent)
 {
     proxy = new EntryProxyModel(model, this);
@@ -37,6 +38,7 @@ ContainersWidget::ContainersWidget(AdModel *model, QWidget *parent)
     view->setItemsExpandable(true);
     view->setExpandsOnDoubleClick(true);
     view->setModel(proxy);
+    entry_context_menu->connect_view(view, AdModel::Column::DN);
 
     column_hidden[AdModel::Column::Name] = false;
     column_hidden[AdModel::Column::Category] = true;

--- a/src/containers_widget.h
+++ b/src/containers_widget.h
@@ -25,6 +25,7 @@
 class QItemSelection;
 class AdModel;
 class EntryProxyModel;
+class EntryContextMenu;
 
 // Display tree of container entries
 // And some other "container-like" entries like domain, built-in, etc
@@ -33,7 +34,7 @@ class ContainersWidget final : public EntryWidget {
 Q_OBJECT
 
 public:
-    ContainersWidget(AdModel *model, QWidget *parent);
+    ContainersWidget(AdModel *model, EntryContextMenu *entry_context_menu, QWidget *parent);
 
 signals:
     void selected_container_changed(const QModelIndex &selected);

--- a/src/contents_widget.cpp
+++ b/src/contents_widget.cpp
@@ -21,12 +21,13 @@
 #include "ad_interface.h"
 #include "ad_model.h"
 #include "entry_proxy_model.h"
+#include "entry_context_menu.h"
 
 #include <QTreeView>
 #include <QLabel>
 #include <QLayout>
 
-ContentsWidget::ContentsWidget(AdModel* model, QWidget *parent)
+ContentsWidget::ContentsWidget(AdModel* model, EntryContextMenu *entry_context_menu, QWidget *parent)
 : EntryWidget(model, parent)
 {   
     proxy = new EntryProxyModel(model, this);
@@ -38,6 +39,7 @@ ContentsWidget::ContentsWidget(AdModel* model, QWidget *parent)
     view->setItemsExpandable(false);
     view->setExpandsOnDoubleClick(false);
     view->setModel(proxy);
+    entry_context_menu->connect_view(view, AdModel::Column::DN);
 
     // Insert label into layout
     const auto label = new QLabel("Contents");

--- a/src/contents_widget.h
+++ b/src/contents_widget.h
@@ -24,13 +24,14 @@
 
 class AdModel;
 class EntryProxyModel;
+class EntryContextMenu;
 
 // Shows name, category and description of children of entry selected in containers view
 class ContentsWidget final : public EntryWidget {
 Q_OBJECT
 
 public:
-    ContentsWidget(AdModel *model, QWidget *parent);
+    ContentsWidget(AdModel *model, EntryContextMenu *entry_context_menu, QWidget *parent);
 
 public slots:
     void on_selected_container_changed(const QModelIndex &source_index);

--- a/src/entry_context_menu.cpp
+++ b/src/entry_context_menu.cpp
@@ -30,7 +30,6 @@
 #include <QPoint>
 
 void EntryContextMenu::on_context_menu_requested(const QString &dn, const QPoint &global_pos) {
-
     clear();
 
     QAction *action_to_show_menu_at = addAction("Details", [this, dn]() {
@@ -84,7 +83,7 @@ void EntryContextMenu::new_entry_dialog(const QString &parent_dn, NewEntryType t
     QString input_label = type_string + " name";
 
     bool ok;
-    QString name = QInputDialog::getText(nullptr, dialog_title, input_label, QLineEdit::Normal, "", &ok);
+    QString name = QInputDialog::getText(this, dialog_title, input_label, QLineEdit::Normal, "", &ok);
 
     // TODO: maybe expand tree to newly created entry?
 
@@ -127,7 +126,7 @@ void EntryContextMenu::rename(const QString &dn) {
     QString dialog_title = "Rename";
     QString input_label = "New name:";
     bool ok;
-    QString new_name = QInputDialog::getText(nullptr, dialog_title, input_label, QLineEdit::Normal, "", &ok);
+    QString new_name = QInputDialog::getText(this, dialog_title, input_label, QLineEdit::Normal, "", &ok);
 
     if (ok && !new_name.isEmpty()) {
         AD()->rename(dn, new_name);

--- a/src/entry_context_menu.cpp
+++ b/src/entry_context_menu.cpp
@@ -28,8 +28,31 @@
 #include <QProcess>
 #include <QDir>
 #include <QPoint>
+#include <QModelIndex>
+#include <QAbstractItemView>
 
-void EntryContextMenu::on_context_menu_requested(const QString &dn, const QPoint &global_pos) {
+// Open this context menu when view requests one
+void EntryContextMenu::connect_view(QAbstractItemView *view, int dn_column) {
+    QObject::connect(
+        view, &QWidget::customContextMenuRequested,
+        [=]
+        (const QPoint pos) {
+            const QModelIndex index = view->indexAt(pos);
+
+            if (!index.isValid()) {
+                return;
+            }
+            
+            QModelIndex dn_index = index.siblingAtColumn(dn_column);
+            QString dn = dn_index.data().toString();
+
+            const QPoint global_pos = view->mapToGlobal(pos);
+
+            this->open(dn, global_pos);
+        });
+}
+
+void EntryContextMenu::open(const QString &dn, const QPoint &global_pos) {
     clear();
 
     QAction *action_to_show_menu_at = addAction("Details", [this, dn]() {

--- a/src/entry_context_menu.cpp
+++ b/src/entry_context_menu.cpp
@@ -1,0 +1,157 @@
+/*
+ * ADMC - AD Management Center
+ *
+ * Copyright (C) 2020 BaseALT Ltd.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "entry_context_menu.h"
+#include "ad_interface.h"
+#include "settings.h"
+#include "confirmation_dialog.h"
+
+#include <QString>
+#include <QMessageBox>
+#include <QInputDialog>
+#include <QProcess>
+#include <QDir>
+#include <QPoint>
+
+void EntryContextMenu::on_context_menu_requested(const QString &dn, const QPoint &global_pos) {
+
+    clear();
+
+    QAction *action_to_show_menu_at = addAction("Details", [this, dn]() {
+        emit details(dn);
+    });
+
+    addAction("Delete", [this, dn]() {
+        delete_entry(dn);
+    });
+    addAction("Rename", [this, dn]() {
+        rename(dn);
+    });
+
+    QMenu *submenu_new = addMenu("New");
+    submenu_new->addAction("New User", [this, dn]() {
+        new_user(dn);
+    });
+    submenu_new->addAction("New Computer", [this, dn]() {
+        new_computer(dn);
+    });
+    submenu_new->addAction("New Group", [this, dn]() {
+        new_group(dn);
+    });
+    submenu_new->addAction("New OU", [this, dn]() {
+        new_ou(dn);
+    });
+
+    const bool is_policy = AD()->is_policy(dn); 
+    if (is_policy) {
+        submenu_new->addAction("Edit Policy", [this, dn]() {
+            edit_policy(dn);
+        });
+    }
+
+    exec(global_pos, action_to_show_menu_at);
+}
+
+void EntryContextMenu::delete_entry(const QString &dn) {
+    const QString name = AD()->get_attribute(dn, "name");
+    const QString text = QString("Are you sure you want to delete \"%1\"?").arg(name);
+    const bool confirmed = confirmation_dialog(text, this);
+
+    if (confirmed) {
+        AD()->delete_entry(dn);
+    }    
+}
+
+void EntryContextMenu::new_entry_dialog(const QString &parent_dn, NewEntryType type) {
+    QString type_string = new_entry_type_to_string[type];
+    QString dialog_title = "New " + type_string;
+    QString input_label = type_string + " name";
+
+    bool ok;
+    QString name = QInputDialog::getText(nullptr, dialog_title, input_label, QLineEdit::Normal, "", &ok);
+
+    // TODO: maybe expand tree to newly created entry?
+
+    // Create user once dialog is complete
+    if (ok && !name.isEmpty()) {
+        // Attempt to create user in AD
+
+        const QMap<NewEntryType, QString> new_entry_type_to_suffix = {
+            {NewEntryType::User, "CN"},
+            {NewEntryType::Computer, "CN"},
+            {NewEntryType::OU, "OU"},
+            {NewEntryType::Group, "CN"},
+        };
+        QString suffix = new_entry_type_to_suffix[type];
+
+        const QString dn = suffix + "=" + name + "," + parent_dn;
+
+        AD()->create_entry(name, dn, type);
+    }
+}
+
+void EntryContextMenu::new_user(const QString &dn) {
+    new_entry_dialog(dn, NewEntryType::User);
+}
+
+void EntryContextMenu::new_computer(const QString &dn) {
+    new_entry_dialog(dn, NewEntryType::Computer);
+}
+
+void EntryContextMenu::new_group(const QString &dn) {
+    new_entry_dialog(dn, NewEntryType::Group);
+}
+
+void EntryContextMenu::new_ou(const QString &dn) {
+    new_entry_dialog(dn, NewEntryType::OU);
+}
+
+void EntryContextMenu::rename(const QString &dn) {
+    // Get new name from input box
+    QString dialog_title = "Rename";
+    QString input_label = "New name:";
+    bool ok;
+    QString new_name = QInputDialog::getText(nullptr, dialog_title, input_label, QLineEdit::Normal, "", &ok);
+
+    if (ok && !new_name.isEmpty()) {
+        AD()->rename(dn, new_name);
+    }
+}
+
+void EntryContextMenu::edit_policy(const QString &dn) {
+    // Start policy edit process
+    const auto process = new QProcess(this);
+
+    const QString program_name = "../gpgui";
+    process->setProgram(QDir::currentPath() + program_name);
+
+    const char *uri = "ldap://dc0.domain.alt";
+
+    const QString path = AD()->get_attribute(dn, "gPCFileSysPath");
+
+    QStringList args;
+    args << uri;
+    args << path;
+    process->setArguments(args);
+
+    printf("on_action_edit_policy\ndn=%s\npath=%s\n", qPrintable(dn), qPrintable(path));
+    printf("execute command: %s %s %s\n", qPrintable(program_name), qPrintable(uri), qPrintable(path));
+
+    process->start();
+}

--- a/src/entry_context_menu.h
+++ b/src/entry_context_menu.h
@@ -26,6 +26,7 @@
 
 class QString;
 class QPoint;
+class QAbstractItemView;
 
 class EntryContextMenu final : public QMenu {
 Q_OBJECT
@@ -33,13 +34,14 @@ Q_OBJECT
 public:
     using QMenu::QMenu;
 
+    void connect_view(QAbstractItemView *view, int dn_column);
+
 signals:
     void details(const QString &dn);
-
-public slots:
-    void on_context_menu_requested(const QString &dn, const QPoint &global_pos);
-
+    
 private:
+    void open(const QString &dn, const QPoint &global_pos);
+
     void delete_entry(const QString &dn);
     void new_entry_dialog(const QString &parent_dn, NewEntryType type);
     void new_user(const QString &dn);

--- a/src/entry_context_menu.h
+++ b/src/entry_context_menu.h
@@ -17,23 +17,38 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef MAIN_WINDOW_H
-#define MAIN_WINDOW_H
+#ifndef ENTRY_CONTEXT_MENU_H
+#define ENTRY_CONTEXT_MENU_H
 
-#include <QMainWindow>
+#include "ad_interface.h"
 
-class MainWindow final : public QMainWindow {
+#include <QMenu>
+
+class QString;
+class QPoint;
+
+class EntryContextMenu final : public QMenu {
 Q_OBJECT
 
 public:
-    explicit MainWindow(const bool auto_login);
+    using QMenu::QMenu;
 
-private slots:
-    void on_action_login();
-    void on_action_exit();
+signals:
+    void details(const QString &dn);
+
+public slots:
+    void on_context_menu_requested(const QString &dn, const QPoint &global_pos);
 
 private:
-    
+    void delete_entry(const QString &dn);
+    void new_entry_dialog(const QString &parent_dn, NewEntryType type);
+    void new_user(const QString &dn);
+    void new_computer(const QString &dn);
+    void new_group(const QString &dn);
+    void new_ou(const QString &dn);
+    void rename(const QString &dn);
+    void edit_policy(const QString &dn);
+
 };
 
-#endif /* MAIN_WINDOW_H */
+#endif /* ENTRY_CONTEXT_MENU_H */

--- a/src/entry_widget.cpp
+++ b/src/entry_widget.cpp
@@ -51,10 +51,6 @@ EntryWidget::EntryWidget(EntryModel *model, QWidget *parent)
         this, &EntryWidget::on_toggle_show_dn_column);
 
     connect(
-        view, &QWidget::customContextMenuRequested,
-        this, &EntryWidget::on_view_context_menu_requested);
-
-    connect(
         view, &QAbstractItemView::clicked,
         this, &EntryWidget::on_view_clicked);
     connect(
@@ -72,22 +68,6 @@ EntryWidget::EntryWidget(EntryModel *model, QWidget *parent)
 void EntryWidget::on_ad_interface_login_complete(const QString &base, const QString &head) {
     // Enable on login
     setEnabled(true);
-}
-
-void EntryWidget::on_view_context_menu_requested(const QPoint &pos) {
-    // Open entry context menu
-    const QModelIndex index = view->indexAt(pos);
-
-    if (!index.isValid()) {
-        return;
-    }
-    
-    const QString dn = entry_model->get_dn_from_index(index);
-    const QPoint global_pos = view->mapToGlobal(pos);
-
-    emit context_menu_requested(dn, global_pos);
-    
-    
 }
 
 void EntryWidget::on_toggle_show_dn_column(bool checked) {

--- a/src/entry_widget.cpp
+++ b/src/entry_widget.cpp
@@ -22,17 +22,8 @@
 #include "entry_model.h"
 #include "settings.h"
 
-#include <QApplication>
-#include <QItemSelection>
-#include <QSortFilterProxyModel>
-#include <QMouseEvent>
-#include <QDrag>
-#include <QMimeData>
 #include <QTreeView>
-#include <QHeaderView>
-#include <QLabel>
 #include <QVBoxLayout>
-#include <QMenu>
 #include <QAction>
 
 EntryWidget::EntryWidget(EntryModel *model, QWidget *parent)
@@ -61,7 +52,7 @@ EntryWidget::EntryWidget(EntryModel *model, QWidget *parent)
 
     connect(
         view, &QWidget::customContextMenuRequested,
-        this, &EntryWidget::on_context_menu_requested);
+        this, &EntryWidget::on_view_context_menu_requested);
 
     connect(
         view, &QAbstractItemView::clicked,
@@ -83,51 +74,20 @@ void EntryWidget::on_ad_interface_login_complete(const QString &base, const QStr
     setEnabled(true);
 }
 
-void EntryWidget::on_context_menu_requested(const QPoint &pos) {
+void EntryWidget::on_view_context_menu_requested(const QPoint &pos) {
     // Open entry context menu
-    QModelIndex index = view->indexAt(pos);
+    const QModelIndex index = view->indexAt(pos);
 
     if (!index.isValid()) {
         return;
     }
     
     const QString dn = entry_model->get_dn_from_index(index);
+    const QPoint global_pos = view->mapToGlobal(pos);
+
+    emit context_menu_requested(dn, global_pos);
     
-    QMenu menu;
-
-    QAction *action_to_show_menu_at = menu.addAction("Details", [this, dn]() {
-        emit context_menu_details(dn);
-    });
-    menu.addAction("Delete", [this, dn]() {
-        emit context_menu_delete(dn);
-    });
-    menu.addAction("Rename", [this, dn]() {
-        emit context_menu_rename(dn);
-    });
-
-    QMenu *submenu_new = menu.addMenu("New");
-    submenu_new->addAction("New User", [this, dn]() {
-        emit context_menu_new_user(dn);
-    });
-    submenu_new->addAction("New Computer", [this, dn]() {
-        emit context_menu_new_computer(dn);
-    });
-    submenu_new->addAction("New Group", [this, dn]() {
-        emit context_menu_new_group(dn);
-    });
-    submenu_new->addAction("New OU", [this, dn]() {
-        emit context_menu_new_ou(dn);
-    });
-
-    const bool is_policy = AD()->is_policy(dn); 
-    if (is_policy) {
-        submenu_new->addAction("Edit Policy", [this, dn]() {
-            emit context_menu_edit_policy(dn);
-        });
-    }
-
-    QPoint global_pos = view->mapToGlobal(pos);
-    menu.exec(global_pos, action_to_show_menu_at);
+    
 }
 
 void EntryWidget::on_toggle_show_dn_column(bool checked) {

--- a/src/entry_widget.h
+++ b/src/entry_widget.h
@@ -37,19 +37,12 @@ public:
     EntryWidget(EntryModel *model, QWidget *parent);
 
 signals:
+    void context_menu_requested(const QString &dn, const QPoint &global_pos);
     void clicked_dn(const QString &dn);
-    void context_menu_details(const QString &dn);
-    void context_menu_rename(const QString &dn);
-    void context_menu_delete(const QString &dn);
-    void context_menu_new_user(const QString &dn);
-    void context_menu_new_computer(const QString &dn);
-    void context_menu_new_group(const QString &dn);
-    void context_menu_new_ou(const QString &dn);
-    void context_menu_edit_policy(const QString &dn);
 
 private slots:
     void on_toggle_show_dn_column(bool checked);
-    void on_context_menu_requested(const QPoint &pos);
+    void on_view_context_menu_requested(const QPoint &pos);
     void on_view_clicked(const QModelIndex &index);
     void on_ad_interface_login_complete(const QString &base, const QString &head);
 

--- a/src/entry_widget.h
+++ b/src/entry_widget.h
@@ -37,12 +37,10 @@ public:
     EntryWidget(EntryModel *model, QWidget *parent);
 
 signals:
-    void context_menu_requested(const QString &dn, const QPoint &global_pos);
     void clicked_dn(const QString &dn);
 
 private slots:
     void on_toggle_show_dn_column(bool checked);
-    void on_view_context_menu_requested(const QPoint &pos);
     void on_view_clicked(const QModelIndex &index);
     void on_ad_interface_login_complete(const QString &base, const QString &head);
 

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -30,6 +30,8 @@
 #include "status.h"
 #include "entry_widget.h"
 #include "settings.h"
+#include "entry_context_menu.h"
+#include "confirmation_dialog.h"
 
 #include <QApplication>
 #include <QString>
@@ -39,11 +41,7 @@
 #include <QSplitter>
 #include <QStatusBar>
 #include <QTreeView>
-#include <QDir>
-#include <QProcess>
 #include <QVBoxLayout>
-#include <QInputDialog>
-#include <QMessageBox>
 #include <QTextEdit>
 
 MainWindow::MainWindow(const bool auto_login)
@@ -91,6 +89,8 @@ MainWindow::MainWindow(const bool auto_login)
     auto status_log = new QTextEdit(this);
     status_log->setReadOnly(true);
 
+    auto entry_context_menu = new EntryContextMenu(this);
+
     new Status(statusBar(), status_log, this);
 
     // Layout
@@ -129,9 +129,21 @@ MainWindow::MainWindow(const bool auto_login)
             contents_widget, &EntryWidget::clicked_dn,
             details_widget, &DetailsWidget::on_contents_clicked_dn);
         
-        connect_entry_widget(containers_widget, details_widget);
-        connect_entry_widget(contents_widget, details_widget);
-        connect_entry_widget(members_widget, details_widget);
+        // Connect entry widgets to entry context menu
+        QList<EntryWidget *> entry_widgets = {
+            containers_widget,
+            contents_widget,
+            members_widget
+        };
+        for (auto e : entry_widgets) {
+            connect(
+                e, &EntryWidget::context_menu_requested,
+                entry_context_menu, &EntryContextMenu::on_context_menu_requested);
+        }
+
+        connect(
+            entry_context_menu, &EntryContextMenu::details,
+            details_widget, &DetailsWidget::on_context_menu_details);
     }
 
     if (auto_login) {
@@ -145,140 +157,9 @@ void MainWindow::on_action_login() {
 
 void MainWindow::on_action_exit() {
     const QString text = QString("Are you sure you want to exit?");
-    const bool confirmed = confirmation_dialog(text);
+    const bool confirmed = confirmation_dialog(text, this);
 
     if (confirmed) {
         QApplication::quit();
     }   
-}
-
-bool MainWindow::confirmation_dialog(const QString &text) {
-    const bool confirm_actions = SETTINGS()->confirm_actions->isChecked();
-    if (!confirm_actions) {
-        return true;
-    }
-
-    const QString title = "ADMC";
-    const QMessageBox::StandardButton reply = QMessageBox::question(this, title, text, QMessageBox::Yes|QMessageBox::No);
-
-    if (reply == QMessageBox::Yes) {
-        return true;
-    } else {
-        return false;
-    }
-}
-
-void MainWindow::connect_entry_widget(EntryWidget *widget, DetailsWidget *details_widget) {
-    connect(
-        widget, &EntryWidget::context_menu_details,
-        details_widget, &DetailsWidget::on_context_menu_details);
-    connect(
-        widget, &EntryWidget::context_menu_rename,
-        this, &MainWindow::on_context_menu_rename);
-    connect(
-        widget, &EntryWidget::context_menu_delete,
-        this, &MainWindow::on_context_menu_delete);
-    connect(
-        widget, &EntryWidget::context_menu_new_user,
-        this, &MainWindow::on_context_menu_new_user);
-    connect(
-        widget, &EntryWidget::context_menu_new_computer,
-        this, &MainWindow::on_context_menu_new_computer);
-    connect(
-        widget, &EntryWidget::context_menu_new_group,
-        this, &MainWindow::on_context_menu_new_group);
-    connect(
-        widget, &EntryWidget::context_menu_new_ou,
-        this, &MainWindow::on_context_menu_new_ou);
-    connect(
-        widget, &EntryWidget::context_menu_edit_policy,
-        this, &MainWindow::on_context_menu_edit_policy);
-}
-
-void MainWindow::on_context_menu_delete(const QString &dn) {
-    const QString name = AD()->get_attribute(dn, "name");
-    const QString text = QString("Are you sure you want to delete \"%1\"?").arg(name);
-    const bool confirmed = confirmation_dialog(text);
-
-    if (confirmed) {
-        AD()->delete_entry(dn);
-    }    
-}
-
-void MainWindow::new_entry_dialog(const QString &parent_dn, NewEntryType type) {
-    QString type_string = new_entry_type_to_string[type];
-    QString dialog_title = "New " + type_string;
-    QString input_label = type_string + " name";
-
-    bool ok;
-    QString name = QInputDialog::getText(nullptr, dialog_title, input_label, QLineEdit::Normal, "", &ok);
-
-    // TODO: maybe expand tree to newly created entry?
-
-    // Create user once dialog is complete
-    if (ok && !name.isEmpty()) {
-        // Attempt to create user in AD
-
-        const QMap<NewEntryType, QString> new_entry_type_to_suffix = {
-            {NewEntryType::User, "CN"},
-            {NewEntryType::Computer, "CN"},
-            {NewEntryType::OU, "OU"},
-            {NewEntryType::Group, "CN"},
-        };
-        QString suffix = new_entry_type_to_suffix[type];
-
-        const QString dn = suffix + "=" + name + "," + parent_dn;
-
-        AD()->create_entry(name, dn, type);
-    }
-}
-
-void MainWindow::on_context_menu_new_user(const QString &dn) {
-    new_entry_dialog(dn, NewEntryType::User);
-}
-
-void MainWindow::on_context_menu_new_computer(const QString &dn) {
-    new_entry_dialog(dn, NewEntryType::Computer);
-}
-
-void MainWindow::on_context_menu_new_group(const QString &dn) {
-    new_entry_dialog(dn, NewEntryType::Group);
-}
-
-void MainWindow::on_context_menu_new_ou(const QString &dn) {
-    new_entry_dialog(dn, NewEntryType::OU);
-}
-
-void MainWindow::on_context_menu_rename(const QString &dn) {
-    // Get new name from input box
-    QString dialog_title = "Rename";
-    QString input_label = "New name:";
-    bool ok;
-    QString new_name = QInputDialog::getText(nullptr, dialog_title, input_label, QLineEdit::Normal, "", &ok);
-
-    if (ok && !new_name.isEmpty()) {
-        AD()->rename(dn, new_name);
-    }
-}
-
-void MainWindow::on_context_menu_edit_policy(const QString &dn) {
-    // Start policy edit process
-    const auto process = new QProcess(this);
-
-    const QString program_name = "../gpgui";
-    process->setProgram(QDir::currentPath() + program_name);
-
-    const char *uri = "ldap://dc0.domain.alt";
-
-    const QString path = AD()->get_attribute(dn, "gPCFileSysPath");
-
-    QStringList args;
-    args << uri;
-    args << path;
-    process->setArguments(args);
-
-    printf("on_action_edit_policy\ndn=%s\npath=%s\n", qPrintable(dn), qPrintable(path));
-    printf("execute command: %s %s %s\n", qPrintable(program_name), qPrintable(uri), qPrintable(path));
-
-    process->start();
 }

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -77,19 +77,19 @@ MainWindow::MainWindow(const bool auto_login)
     auto central_widget = new QWidget(this);
     setCentralWidget(central_widget);
 
+    auto entry_context_menu = new EntryContextMenu(this);
+   
     auto ad_model = new AdModel(this);
-    auto containers_widget = new ContainersWidget(ad_model, this);
-    auto contents_widget = new ContentsWidget(ad_model, this);
+    auto containers_widget = new ContainersWidget(ad_model, entry_context_menu, this);
+    auto contents_widget = new ContentsWidget(ad_model, entry_context_menu, this);
 
     auto members_model = new MembersModel(this);
-    auto members_widget = new MembersWidget(members_model, this);
+    auto members_widget = new MembersWidget(members_model, entry_context_menu, this);
     
     auto details_widget = new DetailsWidget(members_widget, this);
 
     auto status_log = new QTextEdit(this);
     status_log->setReadOnly(true);
-
-    auto entry_context_menu = new EntryContextMenu(this);
 
     new Status(statusBar(), status_log, this);
 
@@ -128,19 +128,6 @@ MainWindow::MainWindow(const bool auto_login)
         connect(
             contents_widget, &EntryWidget::clicked_dn,
             details_widget, &DetailsWidget::on_contents_clicked_dn);
-        
-        // Connect entry widgets to entry context menu
-        QList<EntryWidget *> entry_widgets = {
-            containers_widget,
-            contents_widget,
-            members_widget
-        };
-        for (auto e : entry_widgets) {
-            connect(
-                e, &EntryWidget::context_menu_requested,
-                entry_context_menu, &EntryContextMenu::on_context_menu_requested);
-        }
-
         connect(
             entry_context_menu, &EntryContextMenu::details,
             details_widget, &DetailsWidget::on_context_menu_details);

--- a/src/members_widget.cpp
+++ b/src/members_widget.cpp
@@ -19,11 +19,12 @@
 
 #include "members_widget.h"
 #include "members_model.h"
+#include "entry_context_menu.h"
 
 #include <QTreeView>
 #include <QLabel>
 
-MembersWidget::MembersWidget(MembersModel *model, QWidget *parent)
+MembersWidget::MembersWidget(MembersModel *model, EntryContextMenu *entry_context_menu, QWidget *parent)
 : EntryWidget(model, parent)
 {   
     members_model = model;
@@ -31,6 +32,7 @@ MembersWidget::MembersWidget(MembersModel *model, QWidget *parent)
     view->setEditTriggers(QAbstractItemView::NoEditTriggers);
     view->setAcceptDrops(true);
     view->setModel(members_model);
+    entry_context_menu->connect_view(view, MembersModel::Column::DN);
 
     column_hidden[MembersModel::Column::Name] = false;
     update_column_visibility();

--- a/src/members_widget.h
+++ b/src/members_widget.h
@@ -24,13 +24,14 @@
 
 class MembersModel;
 class QString;
+class EntryContextMenu;
 
 // Shows member entries of targeted group
 class MembersWidget final : public EntryWidget {
 Q_OBJECT
 
 public:
-    MembersWidget(MembersModel *model, QWidget *parent);
+    MembersWidget(MembersModel *model, EntryContextMenu *entry_context_menu, QWidget *parent);
 
     void change_target(const QString &dn);
 


### PR DESCRIPTION
Move entry context menu stuff into it's own file/class. This removes the weird connections between MainWindow and EntryWidget. Also move confirmation_dialog() into it's own file since it's now used by both MainWindow and EntryContextMenu.

Also move connecting view and context menu out of EntryWidget. This way can connect context menu to any view that has DN's.