### PR TITLE
Domains

### DIFF
--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -57,7 +57,7 @@ char *bindpw=NULL;
 //char* search_base = "DC=domain,DC=alt";
 
 // TODO: use this in other appropriate places, like AdInterface
-size_t ad_array_size(const void **array) {
+size_t ad_array_size(const char **array) {
     size_t count = 0;
 
     for (int i = 0; array[i] != NULL; i++) {
@@ -67,7 +67,7 @@ size_t ad_array_size(const void **array) {
     return count;
 }
 
-void ad_array_free(void **array) {
+void ad_array_free(char **array) {
     if (array == NULL) {
         return;
     }

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -51,13 +51,17 @@ char *bindpw=NULL;
 
 // TODO: use this in other appropriate places, like AdInterface
 size_t ad_array_size(char **array) {
-    size_t count = 0;
+    if (array == NULL) {
+        return 0;
+    } else {
+        size_t count = 0;
 
-    for (int i = 0; array[i] != NULL; i++) {
-        count++;
+        for (int i = 0; array[i] != NULL; i++) {
+            count++;
+        }
+
+        return count;
     }
-
-    return count;
 }
 
 void ad_array_free(char **array) {

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -260,7 +260,7 @@ int ad_get_domain_hosts(const char *domain, const char *site, char ***hosts) {
     // TODO: confirm site query is formatted properly, currently getting no answer back (might be working as intended, since tested on domain without sites?)
 
     // Query site hosts
-    if (site != NULL) {
+    if (site != NULL && strlen(site) > 0) {
         char dname[1000];
         snprintf(dname, sizeof(dname), "_ldap._tcp.%s._sites.%s", site, domain);
 

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -65,15 +65,13 @@ size_t ad_array_size(char **array) {
 }
 
 void ad_array_free(char **array) {
-    if (array == NULL) {
-        return;
-    }
+    if (array != NULL) {
+        for (int i = 0; array[i] != NULL; i++) {
+            free(array[i]);
+        }
 
-    for (int i = 0; array[i] != NULL; i++) {
-        free(array[i]);
+        free(array);
     }
-
-    free(array);
 }
 
 typedef struct sasl_defaults_gssapi {
@@ -131,7 +129,6 @@ int sasl_interact_gssapi(LDAP *ds, unsigned flags, void *indefaults, void *in) {
     return LDAP_SUCCESS;
 }
 
-// hosts must be NULL
 // NOTE: this is rewritten from
 // https://github.com/paleg/libadclient/blob/master/adclient.cpp
 // which itself is copied from
@@ -140,7 +137,7 @@ int sasl_interact_gssapi(LDAP *ds, unsigned flags, void *indefaults, void *in) {
 // https://www.gnu.org/software/shishi/coverage/shishi/lib/resolv.c.gcov.html
 int query_server_for_hosts(const char *dname, char ***hosts) {
     if (*hosts != NULL) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in query_server_for_hosts(%s): hosts pointer is not NULL\n", dname);
+        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in query_server_for_hosts(%s): hosts arg is not NULL\n", dname);
         goto error;
     }
 
@@ -149,7 +146,7 @@ int query_server_for_hosts(const char *dname, char ***hosts) {
         unsigned char buf[NS_MAXMSG];
     } msg;
 
-    const size_t msg_len = res_search(dname, ns_c_in, ns_t_srv, msg.buf, sizeof(msg.buf));
+    const int msg_len = res_search(dname, ns_c_in, ns_t_srv, msg.buf, sizeof(msg.buf));
 
     if (msg_len < 0 || msg_len < sizeof(HEADER)) {
         snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in query_server_for_hosts(%s): bad msg_len\n", dname);
@@ -198,6 +195,7 @@ int query_server_for_hosts(const char *dname, char ***hosts) {
         GETSHORT(record_class, curr);
         GETLONG(ttl, curr);
         GETSHORT(record_len, curr);
+        
         unsigned char *record_end = curr + record_len;
         if (record_end > eom) {
             snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in query_server_for_hosts(%s): record_end > eom\n", dname);

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -31,6 +31,8 @@
 #include <string.h>
 #include <stdlib.h>
 #include <ctype.h>
+#include <resolv.h>
+#include <stdbool.h>
 
 #include <errno.h>
 
@@ -47,6 +49,19 @@ char *bindpw=NULL;
 // TODO: unhardcode this
 //char* uri = "ldap://dc0.domain.alt";
 //char* search_base = "DC=domain,DC=alt";
+
+// TODO: use this in other appropriate places, like AdInterface
+void ad_free_null_terminated_array(void **array) {
+    if (array == NULL) {
+        return;
+    }
+
+    for (int i = 0; array[i] != NULL; i++) {
+        free(array[i]);
+    }
+
+    free(array);
+}
 
 typedef struct sasl_defaults_gssapi {
     char *mech;
@@ -140,11 +155,209 @@ char **get_values(LDAP *ds, LDAPMessage *entry) {
     
 }
 
+// NOTE: this is rewritten from
+// https://github.com/paleg/libadclient/blob/master/adclient.cpp
+// which itself is copied from
+// https://www.ccnx.org/releases/latest/doc/ccode/html/ccndc-srv_8c_source.html
+// Another example of similar procedure:
+// https://www.gnu.org/software/shishi/coverage/shishi/lib/resolv.c.gcov.html
+int query_server_for_hosts(const char *dname, char ***hosts, int *hosts_size) {
+    if (*hosts != NULL) {
+        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in query_server_for_hosts() for %s: hosts arg is not NULL\n", dname);
+        goto error;
+    }
+
+    union dns_msg {
+        HEADER header;
+        unsigned char buf[NS_MAXMSG];
+    } msg;
+
+    const size_t msg_len = res_search(dname, ns_c_in, ns_t_srv, msg.buf, sizeof(msg.buf));
+
+    if (msg_len < 0 || msg_len < sizeof(HEADER)) {
+        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in query_server_for_hosts() for %s: bad msg_len\n", dname);
+        goto error;
+    }
+
+    const int packet_count = ntohs(msg.header.qdcount);
+    const int answer_count = ntohs(msg.header.ancount);
+
+    unsigned char *curr = msg.buf + sizeof(msg.header);
+    const unsigned char *eom = msg.buf + msg_len;
+
+    // Skip over packet records
+    for (int i = packet_count; i > 0 && curr < eom; i--) {
+        const int packet_len = dn_skipname(curr, eom);
+
+        if (packet_len < 0) {
+            snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in query_server_for_hosts() for %s: dn_skipname < 0\n", dname);
+            goto error;
+        }
+
+        curr = curr + packet_len + QFIXEDSZ;
+    }
+
+    // Init hosts list
+    *hosts = malloc(sizeof(char *) * (answer_count + 1));
+    for (int i = 0; i < answer_count + 1; i++) {
+        (*hosts)[i] = NULL;
+    }
+    *hosts_size = 0;
+
+    // Process answers by collecting hosts into list
+    for (int i = 0; i < answer_count; i++) {
+        // Get server
+        char server[NS_MAXDNAME];
+        const int server_len = dn_expand(msg.buf, eom, curr, server, sizeof(server));
+        if (server_len < 0) {
+            snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in query_server_for_hosts() for %s: dn_expand(server) < 0\n", dname);
+            goto error;
+        }
+        curr = curr + server_len;
+
+        int record_type, record_class, ttl, record_len;
+        GETSHORT(record_type, curr);
+        GETSHORT(record_class, curr);
+        GETLONG(ttl, curr);
+        GETSHORT(record_len, curr);
+
+        unsigned char *record_end = curr + record_len;
+        if (record_end > eom) {
+            snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in query_server_for_hosts() for %s: record_end > eom\n", dname);
+            goto error;
+        }
+
+        // Skip non-server records
+        if (record_type != ns_t_srv) {
+            curr = record_end;
+            continue;
+        }
+
+        int priority, weight, port;
+        GETSHORT(priority, curr);
+        GETSHORT(weight, curr);
+        GETSHORT(port, curr);
+        // TODO: need to save port field? maybe to incorporate into uri
+
+        // Get host
+        char host[NS_MAXDNAME];
+        const int host_len = dn_expand(msg.buf, eom, curr, host, sizeof(host));
+        if (host_len < 0) {
+            snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in query_server_for_hosts() for %s: dn_expand(host) < 0\n", dname);
+            goto error;
+        }
+
+        (*hosts)[i] = strdup(host);
+        (*hosts_size)++;
+
+        curr = record_end;
+    }
+
+    return AD_SUCCESS;
+
+    error:
+    {
+        ad_free_null_terminated_array(*hosts);
+        *hosts = NULL;
+
+        return AD_RESOLV_ERROR;
+    }
+}
+
+int ad_get_domain_hosts(char *domain, char *site, char ***hosts) {
+    char **site_hosts = NULL;
+    char **default_hosts = NULL;
+
+    int result = AD_SUCCESS; 
+
+    if (*hosts != NULL) {
+        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ad_get_domain_hosts(%s, %s): hosts arg is not NULL\n", domain, site);
+        result = AD_RESOLV_ERROR;
+        goto end;
+    }
+
+    // TODO: confirm site query is formatted properly, currently getting no answer back (might be working as intended, since tested on domain without sites?)
+
+    // Query site hosts
+    int site_hosts_size;
+    if (site != NULL) {
+        char dname[1000];
+        snprintf(dname, sizeof(dname), "_ldap._tcp.%s._sites.%s", site, domain);
+
+        int query_result = query_server_for_hosts(dname, &site_hosts, &site_hosts_size);
+        if (query_result != AD_SUCCESS) {
+            result = query_result;
+            goto end;
+        }
+    }
+
+    // Query default hosts
+    char dname_default[1000];
+    snprintf(dname_default, sizeof(dname_default), "_ldap._tcp.%s", domain);
+
+    int default_hosts_size;
+    int query_result = query_server_for_hosts(dname_default, &default_hosts, &default_hosts_size);
+    if (query_result != AD_SUCCESS) {
+        result = query_result;
+        goto end;
+    }
+
+    // Combine site and default hosts
+    const int hosts_max_size = site_hosts_size + default_hosts_size + 1;
+    *hosts = malloc(sizeof(char *) * hosts_max_size);
+    int hosts_size = 0;
+    
+    // Load all site hosts first
+    for (int i = 0; i < site_hosts_size; i++) {
+        char *site_host = site_hosts[i];
+        (*hosts)[hosts_size] = strdup(site_host);
+        hosts_size++;
+    }
+
+    // Add default hosts that aren't already in list
+    for (int i = 0; i < default_hosts_size; i++) {
+        char *default_host = default_hosts[i];
+
+        bool already_in_list = false;
+        for (int j = 0; j < hosts_size; j++) {
+            char *other_host = (*hosts)[j];
+
+            if (strcmp(default_host, other_host) == 0) {
+                already_in_list = true;
+                break;
+            }
+        }
+
+        if (!already_in_list) {
+            (*hosts)[hosts_size] = strdup(default_host);
+            hosts_size++;
+        }
+    }
+
+    (*hosts)[hosts_size] = NULL;
+
+    result = AD_SUCCESS;
+
+    end:
+    {
+        ad_free_null_terminated_array(site_hosts);
+        ad_free_null_terminated_array(default_hosts);
+
+        return result;
+    }
+}
 
 /* connect and authenticate to active directory server.
     returns an ldap connection identifier or 0 on error */
 LDAP *ad_login(const char* uri) {
     int version, result, bindresult;
+
+    char **hosts = NULL;
+    int hosts_result = ad_get_domain_hosts("DOMAIN.ALT", "SITE", &hosts);
+    for (int i = 0; hosts[i] != NULL; i++) {
+        printf("%s\n", hosts[i]);
+    }
+    ad_free_null_terminated_array(hosts);
 
     /* open the connection to the ldap server */
     LDAP *ds = NULL;

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -51,7 +51,7 @@ char *bindpw=NULL;
 //char* search_base = "DC=domain,DC=alt";
 
 // TODO: use this in other appropriate places, like AdInterface
-void ad_free_null_terminated_array(void **array) {
+void ad_free_array(void **array) {
     if (array == NULL) {
         return;
     }
@@ -257,7 +257,7 @@ int query_server_for_hosts(const char *dname, char ***hosts, int *hosts_size) {
 
     error:
     {
-        ad_free_null_terminated_array(*hosts);
+        ad_free_array(*hosts);
         *hosts = NULL;
 
         return AD_RESOLV_ERROR;
@@ -340,8 +340,8 @@ int ad_get_domain_hosts(char *domain, char *site, char ***hosts) {
 
     end:
     {
-        ad_free_null_terminated_array(site_hosts);
-        ad_free_null_terminated_array(default_hosts);
+        ad_free_array(site_hosts);
+        ad_free_array(default_hosts);
 
         return result;
     }
@@ -357,7 +357,7 @@ LDAP *ad_login(const char* uri) {
     for (int i = 0; hosts[i] != NULL; i++) {
         printf("%s\n", hosts[i]);
     }
-    ad_free_null_terminated_array(hosts);
+    ad_free_array(hosts);
 
     /* open the connection to the ldap server */
     LDAP *ds = NULL;

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -509,7 +509,7 @@ int dn2domain(const char *dn, char** domain) {
         dc[i] = tolower(dc[i]);
     }
 
-    dn2domain_end:
+dn2domain_end:
     /* Free the memory allocated by ldap_str2dn */
     if (NULL != ldn) {
         ldap_dnfree(ldn);
@@ -605,7 +605,7 @@ int ad_create_user(LDAP *ds, const char *username, const char *dn) {
         ad_error_code=AD_SUCCESS;
     }
 
-    ad_create_user_end:
+ad_create_user_end:
     if (NULL != domain) {
         free(domain);
     }
@@ -1102,7 +1102,7 @@ int ad_rename_user(LDAP *ds, const char *dn, const char *new_name) {
         goto ad_rename_user_end;
     }
 
-    ad_rename_user_end:
+ad_rename_user_end:
     if (NULL != domain) {
         free(domain);
         domain = NULL;
@@ -1170,7 +1170,7 @@ int ad_move_user(LDAP *ds, const char *current_dn, const char *new_container) {
 
     ad_error_code=ad_move(ds, current_dn, new_container);
 
-    ad_move_user_end:
+ad_move_user_end:
     if (NULL != domain) {
         free(domain);
         domain = NULL;

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -50,6 +50,21 @@ char *bindpw=NULL;
 //char* uri = "ldap://dc0.domain.alt";
 //char* search_base = "DC=domain,DC=alt";
 
+typedef struct ad_array {
+    char **data;
+    size_t max_size;
+    size_t size;
+};
+
+AdArray *ad_array_new() {
+    AdArray *array = malloc(sizeof(AdArray));
+    array->data = NULL;
+    array->max_size = 0;
+    array->size = 0;
+
+    return array;
+}
+
 void ad_array_init(AdArray *array, size_t max_size) {
     if (array->data != NULL) {
         printf("ERROR: ad_array_init() called on already initialized array!");
@@ -59,6 +74,10 @@ void ad_array_init(AdArray *array, size_t max_size) {
     array->data = malloc(sizeof(char *) * max_size);
     array->max_size = max_size;
     array->size = 0;
+}
+
+size_t ad_array_size(AdArray *array) {
+    return array->size;
 }
 
 const char *ad_array_get(AdArray *array, size_t i) {
@@ -288,8 +307,8 @@ int query_server_for_hosts(const char *dname, AdArray *hosts) {
 }
 
 int ad_get_domain_hosts(char *domain, char *site, AdArray *hosts) {
-    AdArray site_hosts = {0};
-    AdArray default_hosts = {0};
+    AdArray *site_hosts = ad_array_new();
+    AdArray *default_hosts = ad_array_new();
 
     int result = AD_SUCCESS; 
 
@@ -300,7 +319,7 @@ int ad_get_domain_hosts(char *domain, char *site, AdArray *hosts) {
         char dname[1000];
         snprintf(dname, sizeof(dname), "_ldap._tcp.%s._sites.%s", site, domain);
 
-        int query_result = query_server_for_hosts(dname, &site_hosts);
+        int query_result = query_server_for_hosts(dname, site_hosts);
         if (query_result != AD_SUCCESS) {
             result = query_result;
             goto end;
@@ -311,26 +330,26 @@ int ad_get_domain_hosts(char *domain, char *site, AdArray *hosts) {
     char dname_default[1000];
     snprintf(dname_default, sizeof(dname_default), "_ldap._tcp.%s", domain);
 
-    int query_result = query_server_for_hosts(dname_default, &default_hosts);
+    int query_result = query_server_for_hosts(dname_default, default_hosts);
     if (query_result != AD_SUCCESS) {
         result = query_result;
         goto end;
     }
 
     // Combine site and default hosts
-    const size_t hosts_max_size = site_hosts.size + default_hosts.size;
+    const size_t hosts_max_size = ad_array_size(site_hosts) + ad_array_size(default_hosts);
     ad_array_init(hosts, hosts_max_size);
     
     // Load all site hosts first
-    for (size_t i = 0; i < site_hosts.size; i++) {
-        const char *site_host = ad_array_get(&site_hosts, i);
+    for (size_t i = 0; i < ad_array_size(site_hosts); i++) {
+        const char *site_host = ad_array_get(site_hosts, i);
 
         ad_array_add(hosts, site_host);
     }
 
     // Add default hosts that aren't already in list
-    for (size_t i = 0; i < default_hosts.size; i++) {
-        const char *default_host = ad_array_get(&default_hosts, i);
+    for (size_t i = 0; i < ad_array_size(default_hosts); i++) {
+        const char *default_host = ad_array_get(default_hosts, i);
 
         bool already_in_list = false;
         for (int j = 0; j < hosts->size; j++) {
@@ -351,8 +370,8 @@ int ad_get_domain_hosts(char *domain, char *site, AdArray *hosts) {
 
     end:
     {
-        ad_array_free(&site_hosts);
-        ad_array_free(&default_hosts);
+        ad_array_free(site_hosts);
+        ad_array_free(default_hosts);
 
         return result;
     }

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -241,7 +241,7 @@ int query_server_for_hosts(const char *dname, char ***hosts) {
     }
 }
 
-int ad_get_domain_hosts(char *domain, char *site, char ***hosts) {
+int ad_get_domain_hosts(const char *domain, const char *site, char ***hosts) {
     int result = AD_SUCCESS; 
     
     if (*hosts != NULL) {

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -50,17 +50,51 @@ char *bindpw=NULL;
 //char* uri = "ldap://dc0.domain.alt";
 //char* search_base = "DC=domain,DC=alt";
 
-// TODO: use this in other appropriate places, like AdInterface
-void ad_free_null_terminated_array(void **array) {
-    if (array == NULL) {
+void ad_array_init(AdArray *array, size_t max_size) {
+    if (array->data != NULL) {
+        printf("ERROR: ad_array_init() called on already initialized array!");
         return;
     }
 
-    for (int i = 0; array[i] != NULL; i++) {
-        free(array[i]);
+    array->data = malloc(sizeof(char *) * max_size);
+    array->max_size = max_size;
+    array->size = 0;
+}
+
+const char *ad_array_get(AdArray *array, size_t i) {
+    if (i >= array->size) {
+        printf("ERROR: ad_array_get() out of bounds: i = %lu, size = %lu!", i, array->size);
+        return NULL;
     }
 
-    free(array);
+    return array->data[i];
+}
+
+void ad_array_add(AdArray *array, const char *value) {
+    if (value == NULL) {
+        printf("ERROR: ad_array_add() value is NULL!", array->size);
+        return;
+    }
+
+    if (array->size == array->max_size) {
+        printf("ERROR: ad_array_add() out of bounds: size = %lu!", array->size);
+        return;
+    }
+
+    array->data[array->size] = strdup(value);
+    array->size++;
+}
+
+void ad_array_free(AdArray *array) {
+    char **data = array->data;
+
+    if (data != NULL) {
+        for (int i = 0; i < array->size; i++) {
+            free(data[i]);
+        }
+
+        free(data);
+    }
 }
 
 typedef struct sasl_defaults_gssapi {
@@ -161,12 +195,7 @@ char **get_values(LDAP *ds, LDAPMessage *entry) {
 // https://www.ccnx.org/releases/latest/doc/ccode/html/ccndc-srv_8c_source.html
 // Another example of similar procedure:
 // https://www.gnu.org/software/shishi/coverage/shishi/lib/resolv.c.gcov.html
-int query_server_for_hosts(const char *dname, char ***hosts, int *hosts_size) {
-    if (*hosts != NULL) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in query_server_for_hosts() for %s: hosts arg is not NULL\n", dname);
-        goto error;
-    }
-
+int query_server_for_hosts(const char *dname, AdArray *hosts) {
     union dns_msg {
         HEADER header;
         unsigned char buf[NS_MAXMSG];
@@ -198,11 +227,7 @@ int query_server_for_hosts(const char *dname, char ***hosts, int *hosts_size) {
     }
 
     // Init hosts list
-    *hosts = malloc(sizeof(char *) * (answer_count + 1));
-    for (int i = 0; i < answer_count + 1; i++) {
-        (*hosts)[i] = NULL;
-    }
-    *hosts_size = 0;
+    ad_array_init(hosts, answer_count);
 
     // Process answers by collecting hosts into list
     for (int i = 0; i < answer_count; i++) {
@@ -247,8 +272,7 @@ int query_server_for_hosts(const char *dname, char ***hosts, int *hosts_size) {
             goto error;
         }
 
-        (*hosts)[i] = strdup(host);
-        (*hosts_size)++;
+        ad_array_add(hosts, (const char *)host);
 
         curr = record_end;
     }
@@ -257,34 +281,26 @@ int query_server_for_hosts(const char *dname, char ***hosts, int *hosts_size) {
 
     error:
     {
-        ad_free_null_terminated_array(*hosts);
-        *hosts = NULL;
+        ad_array_free(hosts);
 
         return AD_RESOLV_ERROR;
     }
 }
 
-int ad_get_domain_hosts(char *domain, char *site, char ***hosts) {
-    char **site_hosts = NULL;
-    char **default_hosts = NULL;
+int ad_get_domain_hosts(char *domain, char *site, AdArray *hosts) {
+    AdArray site_hosts = {0};
+    AdArray default_hosts = {0};
 
     int result = AD_SUCCESS; 
-
-    if (*hosts != NULL) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ad_get_domain_hosts(%s, %s): hosts arg is not NULL\n", domain, site);
-        result = AD_RESOLV_ERROR;
-        goto end;
-    }
 
     // TODO: confirm site query is formatted properly, currently getting no answer back (might be working as intended, since tested on domain without sites?)
 
     // Query site hosts
-    int site_hosts_size;
     if (site != NULL) {
         char dname[1000];
         snprintf(dname, sizeof(dname), "_ldap._tcp.%s._sites.%s", site, domain);
 
-        int query_result = query_server_for_hosts(dname, &site_hosts, &site_hosts_size);
+        int query_result = query_server_for_hosts(dname, &site_hosts);
         if (query_result != AD_SUCCESS) {
             result = query_result;
             goto end;
@@ -295,32 +311,30 @@ int ad_get_domain_hosts(char *domain, char *site, char ***hosts) {
     char dname_default[1000];
     snprintf(dname_default, sizeof(dname_default), "_ldap._tcp.%s", domain);
 
-    int default_hosts_size;
-    int query_result = query_server_for_hosts(dname_default, &default_hosts, &default_hosts_size);
+    int query_result = query_server_for_hosts(dname_default, &default_hosts);
     if (query_result != AD_SUCCESS) {
         result = query_result;
         goto end;
     }
 
     // Combine site and default hosts
-    const int hosts_max_size = site_hosts_size + default_hosts_size + 1;
-    *hosts = malloc(sizeof(char *) * hosts_max_size);
-    int hosts_size = 0;
+    const size_t hosts_max_size = site_hosts.size + default_hosts.size;
+    ad_array_init(hosts, hosts_max_size);
     
     // Load all site hosts first
-    for (int i = 0; i < site_hosts_size; i++) {
-        char *site_host = site_hosts[i];
-        (*hosts)[hosts_size] = strdup(site_host);
-        hosts_size++;
+    for (size_t i = 0; i < site_hosts.size; i++) {
+        const char *site_host = ad_array_get(&site_hosts, i);
+
+        ad_array_add(hosts, site_host);
     }
 
     // Add default hosts that aren't already in list
-    for (int i = 0; i < default_hosts_size; i++) {
-        char *default_host = default_hosts[i];
+    for (size_t i = 0; i < default_hosts.size; i++) {
+        const char *default_host = ad_array_get(&default_hosts, i);
 
         bool already_in_list = false;
-        for (int j = 0; j < hosts_size; j++) {
-            char *other_host = (*hosts)[j];
+        for (int j = 0; j < hosts->size; j++) {
+            const char *other_host = ad_array_get(hosts, j);
 
             if (strcmp(default_host, other_host) == 0) {
                 already_in_list = true;
@@ -329,19 +343,16 @@ int ad_get_domain_hosts(char *domain, char *site, char ***hosts) {
         }
 
         if (!already_in_list) {
-            (*hosts)[hosts_size] = strdup(default_host);
-            hosts_size++;
+            ad_array_add(hosts, default_host);
         }
     }
-
-    (*hosts)[hosts_size] = NULL;
 
     result = AD_SUCCESS;
 
     end:
     {
-        ad_free_null_terminated_array(site_hosts);
-        ad_free_null_terminated_array(default_hosts);
+        ad_array_free(&site_hosts);
+        ad_array_free(&default_hosts);
 
         return result;
     }
@@ -351,13 +362,6 @@ int ad_get_domain_hosts(char *domain, char *site, char ***hosts) {
     returns an ldap connection identifier or 0 on error */
 LDAP *ad_login(const char* uri) {
     int version, result, bindresult;
-
-    char **hosts = NULL;
-    int hosts_result = ad_get_domain_hosts("DOMAIN.ALT", "SITE", &hosts);
-    for (int i = 0; hosts[i] != NULL; i++) {
-        printf("%s\n", hosts[i]);
-    }
-    ad_free_null_terminated_array(hosts);
 
     /* open the connection to the ldap server */
     LDAP *ds = NULL;

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -57,7 +57,7 @@ char *bindpw=NULL;
 //char* search_base = "DC=domain,DC=alt";
 
 // TODO: use this in other appropriate places, like AdInterface
-size_t ad_array_size(const char **array) {
+size_t ad_array_size(char **array) {
     size_t count = 0;
 
     for (int i = 0; array[i] != NULL; i++) {

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -377,7 +377,7 @@ LDAP *ad_login(const char* uri) {
 
     char **hosts = NULL;
     int hosts_result = ad_get_domain_hosts("DOMAIN.ALT", "SITE", &hosts);
-    if (hosts != NULL) {
+    if (hosts_result == AD_SUCCESS) {
         for (int i = 0; hosts[i] != NULL; i++) {
             printf("%s\n", hosts[i]);
         }

--- a/adldap/ad_connection.cpp
+++ b/adldap/ad_connection.cpp
@@ -32,13 +32,13 @@ void AdConnection::connect(std::string uri_, std::string search_base_) {
     this->search_base = search_base_;
     this->ldap_connection = ad_login(this->uri.c_str());
 
-    AdArray *hosts = ad_array_new();
-    int hosts_result = ad_get_domain_hosts("DOMAIN.ALT", "SITE", hosts);
-    for (size_t i = 0; i < ad_array_size(hosts); i++) {
-        const char *host = ad_array_get(hosts, i);
+    AdArray hosts = {0};
+    int hosts_result = ad_get_domain_hosts("DOMAIN.ALT", "SITE", &hosts);
+    for (size_t i = 0; i < hosts.size; i++) {
+        const char *host = ad_array_get(&hosts, i);
         printf("%s\n", host);
     }
-    ad_array_free(hosts);
+    ad_array_free(&hosts);
 }
 
 bool AdConnection::is_connected() {

--- a/adldap/ad_connection.cpp
+++ b/adldap/ad_connection.cpp
@@ -31,14 +31,6 @@ void AdConnection::connect(std::string uri_, std::string search_base_) {
     this->uri = uri_;
     this->search_base = search_base_;
     this->ldap_connection = ad_login(this->uri.c_str());
-
-    AdArray hosts = {0};
-    int hosts_result = ad_get_domain_hosts("DOMAIN.ALT", "SITE", &hosts);
-    for (size_t i = 0; i < hosts.size; i++) {
-        const char *host = ad_array_get(&hosts, i);
-        printf("%s\n", host);
-    }
-    ad_array_free(&hosts);
 }
 
 bool AdConnection::is_connected() {

--- a/adldap/ad_connection.cpp
+++ b/adldap/ad_connection.cpp
@@ -32,13 +32,13 @@ void AdConnection::connect(std::string uri_, std::string search_base_) {
     this->search_base = search_base_;
     this->ldap_connection = ad_login(this->uri.c_str());
 
-    AdArray hosts = {0};
-    int hosts_result = ad_get_domain_hosts("DOMAIN.ALT", "SITE", &hosts);
-    for (size_t i = 0; i < hosts.size; i++) {
-        const char *host = ad_array_get(&hosts, i);
+    AdArray *hosts = ad_array_new();
+    int hosts_result = ad_get_domain_hosts("DOMAIN.ALT", "SITE", hosts);
+    for (size_t i = 0; i < ad_array_size(hosts); i++) {
+        const char *host = ad_array_get(hosts, i);
         printf("%s\n", host);
     }
-    ad_array_free(&hosts);
+    ad_array_free(hosts);
 }
 
 bool AdConnection::is_connected() {

--- a/adldap/ad_connection.cpp
+++ b/adldap/ad_connection.cpp
@@ -31,6 +31,14 @@ void AdConnection::connect(std::string uri_, std::string search_base_) {
     this->uri = uri_;
     this->search_base = search_base_;
     this->ldap_connection = ad_login(this->uri.c_str());
+
+    AdArray hosts = {0};
+    int hosts_result = ad_get_domain_hosts("DOMAIN.ALT", "SITE", &hosts);
+    for (size_t i = 0; i < hosts.size; i++) {
+        const char *host = ad_array_get(&hosts, i);
+        printf("%s\n", host);
+    }
+    ad_array_free(&hosts);
 }
 
 bool AdConnection::is_connected() {

--- a/adldap/include/active_directory.h
+++ b/adldap/include/active_directory.h
@@ -63,7 +63,7 @@ void ad_free_array(char **array);
 
 // ad_array_size() returns size of null-terminated array
 // iterates through whole array each time
-size_t ad_array_size(const char **array);
+size_t ad_array_size(char **array);
 
 // ad_get_domain_hosts() returns a null-terminated array of hosts
 // that exist for this domain and site

--- a/adldap/include/active_directory.h
+++ b/adldap/include/active_directory.h
@@ -20,6 +20,14 @@
 extern "C" {
 #endif /* __cplusplus */
 
+typedef struct ad_array {
+    char **data;
+    size_t max_size;
+    size_t size;
+} AdArray;
+const char *ad_array_get(AdArray *array, size_t i);
+void ad_array_free(AdArray *array);
+
 /* Configuration options:
 |  For configuration these functions look first for the file 
 | ~/.adtool.cfg, or failing that
@@ -56,14 +64,9 @@ char *ad_get_error();
 */
 int ad_get_error_num();
 
-// Frees array contents and then array pointer itself
-// Must be a null-terminated array
-// NULL check of array pointer is performed inside
-void ad_free_null_terminated_array(void **array);
-
 // Get hosts for this domain and site, combines site and default hosts
 // hosts list is NULL-terminated
-int ad_get_domain_hosts(char *domain, char *site, char ***hosts);
+int ad_get_domain_hosts(char *domain, char *site, AdArray *hosts);
 
 /* ad_create_user() creates a new, locked user account
 | with the given user name and distinguished name

--- a/adldap/include/active_directory.h
+++ b/adldap/include/active_directory.h
@@ -59,7 +59,11 @@ int ad_get_error_num();
 // ad_free_array() frees a null-terminated array that was returned
 // by one of the functions in this library
 // NULL check of array pointer is performed inside
-void ad_free_array(void **array);
+void ad_free_array(char **array);
+
+// ad_array_size() returns size of null-terminated array
+// iterates through whole array each time
+size_t ad_array_size(const char **array);
 
 // ad_get_domain_hosts() returns a null-terminated array of hosts
 // that exist for this domain and site

--- a/adldap/include/active_directory.h
+++ b/adldap/include/active_directory.h
@@ -20,9 +20,11 @@
 extern "C" {
 #endif /* __cplusplus */
 
-typedef struct ad_array AdArray;
-AdArray *ad_array_new();
-size_t ad_array_size(AdArray *array);
+typedef struct ad_array {
+    char **data;
+    size_t max_size;
+    size_t size;
+} AdArray;
 const char *ad_array_get(AdArray *array, size_t i);
 void ad_array_free(AdArray *array);
 

--- a/adldap/include/active_directory.h
+++ b/adldap/include/active_directory.h
@@ -20,11 +20,9 @@
 extern "C" {
 #endif /* __cplusplus */
 
-typedef struct ad_array {
-    char **data;
-    size_t max_size;
-    size_t size;
-} AdArray;
+typedef struct ad_array AdArray;
+AdArray *ad_array_new();
+size_t ad_array_size(AdArray *array);
 const char *ad_array_get(AdArray *array, size_t i);
 void ad_array_free(AdArray *array);
 

--- a/adldap/include/active_directory.h
+++ b/adldap/include/active_directory.h
@@ -20,14 +20,6 @@
 extern "C" {
 #endif /* __cplusplus */
 
-typedef struct ad_array {
-    char **data;
-    size_t max_size;
-    size_t size;
-} AdArray;
-const char *ad_array_get(AdArray *array, size_t i);
-void ad_array_free(AdArray *array);
-
 /* Configuration options:
 |  For configuration these functions look first for the file 
 | ~/.adtool.cfg, or failing that
@@ -64,9 +56,14 @@ char *ad_get_error();
 */
 int ad_get_error_num();
 
+// Frees array contents and then array pointer itself
+// Must be a null-terminated array
+// NULL check of array pointer is performed inside
+void ad_free_null_terminated_array(void **array);
+
 // Get hosts for this domain and site, combines site and default hosts
 // hosts list is NULL-terminated
-int ad_get_domain_hosts(char *domain, char *site, AdArray *hosts);
+int ad_get_domain_hosts(char *domain, char *site, char ***hosts);
 
 /* ad_create_user() creates a new, locked user account
 | with the given user name and distinguished name

--- a/adldap/include/active_directory.h
+++ b/adldap/include/active_directory.h
@@ -59,7 +59,7 @@ int ad_get_error_num();
 // ad_free_array() frees a null-terminated array that was returned
 // by one of the functions in this library
 // NULL check of array pointer is performed inside
-void ad_free_array(char **array);
+void ad_array_free(char **array);
 
 // ad_array_size() returns size of null-terminated array
 // iterates through whole array each time

--- a/adldap/include/active_directory.h
+++ b/adldap/include/active_directory.h
@@ -56,6 +56,15 @@ char *ad_get_error();
 */
 int ad_get_error_num();
 
+// Frees array contents and then array pointer itself
+// Must be a null-terminated array
+// NULL check of array pointer is performed inside
+void ad_free_null_terminated_array(void **array);
+
+// Get hosts for this domain and site, combines site and default hosts
+// hosts list is NULL-terminated
+int ad_get_domain_hosts(char *domain, char *site, char ***hosts);
+
 /* ad_create_user() creates a new, locked user account
 | with the given user name and distinguished name
 |  Example usage: 
@@ -247,5 +256,6 @@ LDAP *ad_login(const char* uri);
 #define AD_OBJECT_NOT_FOUND 6
 #define AD_ATTRIBUTE_ENTRY_NOT_FOUND 7
 #define AD_INVALID_DN 8
+#define AD_RESOLV_ERROR 9
 
 #endif /* ACTIVE_DIRECTORY_H */

--- a/adldap/include/active_directory.h
+++ b/adldap/include/active_directory.h
@@ -56,17 +56,22 @@ char *ad_get_error();
 */
 int ad_get_error_num();
 
-// ad_free_array() frees a null-terminated array that was returned
-// by one of the functions in this library
-// NULL check of array pointer is performed inside
+/**
+ * Free a null-terminated array that was returned by one of
+ * the functions in this library
+ * NULL check of array pointer is performed inside
+ */
 void ad_array_free(char **array);
 
-// ad_array_size() returns size of null-terminated array
-// iterates through whole array each time
+/**
+ * Calculate size of null-terminated array by iterating through it
+ */
 size_t ad_array_size(char **array);
 
-// ad_get_domain_hosts() returns a null-terminated array of hosts
-// that exist for this domain and site
+/**
+ * Return a null-terminated array of hosts that exist for given
+ * domain and shit
+ */
 int ad_get_domain_hosts(const char *domain, const char *site, char ***hosts);
 
 /* ad_create_user() creates a new, locked user account

--- a/adldap/include/active_directory.h
+++ b/adldap/include/active_directory.h
@@ -67,7 +67,7 @@ size_t ad_array_size(char **array);
 
 // ad_get_domain_hosts() returns a null-terminated array of hosts
 // that exist for this domain and site
-int ad_get_domain_hosts(char *domain, char *site, char ***hosts);
+int ad_get_domain_hosts(const char *domain, const char *site, char ***hosts);
 
 /* ad_create_user() creates a new, locked user account
 | with the given user name and distinguished name

--- a/adldap/include/active_directory.h
+++ b/adldap/include/active_directory.h
@@ -56,13 +56,13 @@ char *ad_get_error();
 */
 int ad_get_error_num();
 
-// Frees array contents and then array pointer itself
-// Must be a null-terminated array
+// ad_free_array() frees a null-terminated array that was returned
+// by one of the functions in this library
 // NULL check of array pointer is performed inside
-void ad_free_null_terminated_array(void **array);
+void ad_free_array(void **array);
 
-// Get hosts for this domain and site, combines site and default hosts
-// hosts list is NULL-terminated
+// ad_get_domain_hosts() returns a null-terminated array of hosts
+// that exist for this domain and site
 int ad_get_domain_hosts(char *domain, char *site, char ***hosts);
 
 /* ad_create_user() creates a new, locked user account


### PR DESCRIPTION
ad_get_domain_hosts() takes domain and site ("DOMAIN.ALT", "SITE") and returns hosts ("dc0.domain.alt").
Need this for the login dialog where you input domain, site and then select hosts from those that are available.

Added ad_array_free() and ad_array_size() to use in ad_get_domain_hosts(). Should use it in other places where those actions are done by hand.