### PR TITLE
improve AD errors

### DIFF
--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -476,7 +476,7 @@ char **ad_search(LDAP *ds, const char *filter, const char* search_base) {
     num_results=ldap_count_entries(ds, res);
     if(num_results==0) {
         ldap_msgfree(res);
-        save_ldap_error_msg("no matches found");
+        save_error_msg("no matches found");
         ad_error_code=AD_OBJECT_NOT_FOUND;
         return NULL;
     }
@@ -684,12 +684,12 @@ char **ad_get_attribute(LDAP *ds, const char *dn, const char *attribute) {
     int entries_count = ldap_count_entries(ds, res);
 
     if(entries_count==0) {
-        save_ldap_error_msg("no attribute values found");
+        save_error_msg("no attribute values found");
         ldap_msgfree(res);
         ad_error_code=AD_OBJECT_NOT_FOUND;
         return NULL;
     } else if(entries_count>1) {
-        save_ldap_error_msg("attribute has multiple values");
+        save_error_msg("attribute has multiple values");
         ldap_msgfree(res);
         ad_error_code=AD_OBJECT_NOT_FOUND;
         return NULL;

--- a/adldap/active_directory.c
+++ b/adldap/active_directory.c
@@ -38,6 +38,11 @@ int ad_error_code;
 
 #define MAX_PASSWORD_LENGTH 255
 
+// Save custom error message
+#define save_error_msg_text(msg) snprintf(ad_error_msg, MAX_ERR_LENGTH, "ERROR %s:%d: %s",  __func__, __LINE__, msg)
+// Convert error code to error message and save it
+#define save_error_msg(err) save_error_msg_text(ldap_err2string(err))
+
 char *binddn=NULL;
 char *bindpw=NULL;
 
@@ -105,7 +110,7 @@ LDAP *ad_login(const char* uri) {
     LDAP *ds = NULL;
     result=ldap_initialize(&ds, uri);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error doing ldap_initialize on uri %s: %s", uri, ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_SERVER_CONNECT_FAILURE;
         return NULL;
     }
@@ -114,7 +119,7 @@ LDAP *ad_login(const char* uri) {
     version=LDAP_VERSION3;
     result=ldap_set_option(ds, LDAP_OPT_PROTOCOL_VERSION, &version);
     if(result!=LDAP_OPT_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ldap_set_option (protocol->v3): %s", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_SERVER_CONNECT_FAILURE;
         return NULL;
     }
@@ -122,7 +127,7 @@ LDAP *ad_login(const char* uri) {
     // disable referrals
     result=ldap_set_option(ds, LDAP_OPT_REFERRALS, LDAP_OPT_OFF);
     if(result!=LDAP_OPT_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ldap_set_option (referrals=0): %s", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_SERVER_CONNECT_FAILURE;
         return NULL;
     }
@@ -131,7 +136,7 @@ LDAP *ad_login(const char* uri) {
     char* sasl_secprops = "maxssf=56";
     result = ldap_set_option(ds, LDAP_OPT_X_SASL_SECPROPS, (void *) sasl_secprops);
     if (result != LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ldap_set_option (LDAP_OPT_X_SASL_SECPROPS): %s", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_SERVER_CONNECT_FAILURE;
         return NULL;
     }
@@ -155,7 +160,7 @@ LDAP *ad_login(const char* uri) {
     ldap_memfree(defaults.authcid);
     ldap_memfree(defaults.authzid);
     if (result != LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ldap_sasl_interactive_bind_s: %s", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_SERVER_CONNECT_FAILURE;
         return NULL;
     }
@@ -315,7 +320,7 @@ int ad_create_user(LDAP *ds, const char *username, const char *dn) {
 
     result = ldap_add_ext_s(ds, dn, attrs, NULL, NULL);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ldap_add_ext_s %s", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
     } else {
         ad_error_code=AD_SUCCESS;
@@ -374,7 +379,7 @@ int ad_create_computer(LDAP *ds, const char *name, const char *dn) {
 
     result = ldap_add_ext_s(ds, dn, attrs, NULL, NULL);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ldap_add_ext_s %s", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
     } else {
         ad_error_code=AD_SUCCESS;
@@ -392,7 +397,7 @@ int ad_object_delete(LDAP *ds, const char *dn) {
 
     result = ldap_delete_ext_s(ds, dn, NULL, NULL);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ldap_delete_ext_s: %s", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
     } else {
         ad_error_code=AD_SUCCESS;
@@ -434,7 +439,7 @@ int ad_setpass(LDAP *ds, const char *dn, const char *password) {
 
     result = ldap_modify_ext_s(ds, dn, attrs, NULL, NULL);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ldap_modify_ext_s for password: %s", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
     } else {
         ad_error_code=AD_SUCCESS;
@@ -531,7 +536,7 @@ int ad_mod_add(LDAP *ds, const char *dn, const char *attribute, const char *valu
 
     result = ldap_modify_ext_s(ds, dn, attrs, NULL, NULL);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ad_mod_add, ldap_modify_ext_s: %s\n", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
     } else {
         ad_error_code=AD_SUCCESS;
@@ -565,7 +570,7 @@ int ad_mod_add_binary(LDAP *ds, const char *dn, const char *attribute, const cha
 
     result = ldap_modify_ext_s(ds, dn, attrs, NULL, NULL);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ad_mod_add_binary, ldap_modify_ext_s: %s\n", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
     } else {
         ad_error_code=AD_SUCCESS;
@@ -595,7 +600,7 @@ int ad_mod_replace(LDAP *ds, const char *dn, const char *attribute, const char *
 
     result = ldap_modify_ext_s(ds, dn, attrs, NULL, NULL);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ad_mod_replace, ldap_modify_ext_s: %s\n", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
     } else {
         ad_error_code=AD_SUCCESS;
@@ -629,7 +634,7 @@ int ad_mod_replace_binary(LDAP *ds, const char *dn, const char *attribute, const
 
     result = ldap_modify_ext_s(ds, dn, attrs, NULL, NULL);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ad_mod_replace_binary, ldap_modify_ext_s: %s\n", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
     } else {
         ad_error_code=AD_SUCCESS;
@@ -659,7 +664,7 @@ int ad_mod_delete(LDAP *ds, const char *dn, const char *attribute, const char *v
 
     result = ldap_modify_ext_s(ds, dn, attrs, NULL, NULL);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ad_mod_replace, ldap_modify_ext_s: %s\n", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
     } else {
         ad_error_code=AD_SUCCESS;
@@ -687,26 +692,20 @@ char **ad_get_attribute(LDAP *ds, const char *dn, const char *attribute) {
     LDAPMessage *res;
     int result = ldap_search_ext_s(ds, dn, LDAP_SCOPE_BASE, "(objectclass=*)", attrs, 0, NULL, NULL, NULL, LDAP_NO_LIMIT, &res);
     if (result != LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ad_get_attribute when calling ldap_search_ext_s: %s",
-            ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
         return NULL;
     }
 
     int entries_count = ldap_count_entries(ds, res);
-    if (entries_count == 0) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "No entries found in ad_get_attribute for user %s.", dn);
-        ad_error_code=AD_OBJECT_NOT_FOUND;
-        return NULL;
-    }
 
     if(entries_count==0) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "No entries found in ad_get_attribute for user %s.\n", dn);
+        save_error_msg(result);
         ldap_msgfree(res);
         ad_error_code=AD_OBJECT_NOT_FOUND;
         return NULL;
     } else if(entries_count>1) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "More than one entry found in ad_get_attributes for user %s.\n", dn);
+        save_error_msg(result);
         ldap_msgfree(res);
         ad_error_code=AD_OBJECT_NOT_FOUND;
         return NULL;
@@ -790,7 +789,7 @@ char **ad_get_attribute(LDAP *ds, const char *dn, const char *attribute) {
 int ad_mod_rename(LDAP *ds, const char *dn, const char *new_rdn) {
     int result = ldap_rename_s(ds, dn, new_rdn, NULL, 1, NULL, NULL);
     if (result != LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ldap_rename_s for ad_mod_rename: %s\n", ldap_err2string(result));
+        save_error_msg(result);
         return ad_error_code;
     }
 
@@ -824,7 +823,7 @@ int ad_rename_user(LDAP *ds, const char *dn, const char *new_name) {
 
     result = ldap_rename_s(ds, dn, new_rdn, NULL, 1, NULL, NULL);
     if (result != LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ldap_rename_s for ad_rename_user: %s\n", ldap_err2string(result));
+        save_error_msg(result);
         goto ad_rename_user_end;
     }
 
@@ -857,7 +856,7 @@ int ad_rename_group(LDAP *ds, const char *dn, const char *new_name) {
 
     result = ldap_rename_s(ds, dn, new_rdn, NULL, 1, NULL, NULL);
     if (result != LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ldap_rename_s for ad_rename_group: %s\n", ldap_err2string(result));
+        save_error_msg(result);
         return ad_error_code;
     }
 
@@ -875,14 +874,12 @@ int ad_move_user(LDAP *ds, const char *current_dn, const char *new_container) {
     // Modify userPrincipalName in case of domain change
     username=ad_get_attribute(ds, current_dn, "sAMAccountName");;
     if(username==NULL) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH,
-          "Error getting username for dn %s for ad_move_user\n",
-          current_dn);
         ad_error_code=AD_INVALID_DN;
         return ad_error_code;
     }
     result_dn2domain = dn2domain(new_container, &domain);
     if (AD_SUCCESS != result_dn2domain) {
+        save_error_msg_text("dn2domain failed");
         ad_error_code = result_dn2domain;
         goto ad_move_user_end;
     }
@@ -914,9 +911,7 @@ int ad_move(LDAP *ds, const char *current_dn, const char *new_container) {
 
     exdn=ldap_explode_dn(current_dn, 0);
     if(exdn==NULL) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH,
-          "Error exploding dn %s for ad_move\n",
-          current_dn);
+        save_error_msg_text("ldap_explode_dn failed");
         ad_error_code=AD_INVALID_DN;
         return ad_error_code;
     }
@@ -925,9 +920,7 @@ int ad_move(LDAP *ds, const char *current_dn, const char *new_container) {
         1, NULL, NULL);
     ldap_memfree(exdn);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH,
-          "Error in ldap_rename_s for ad_move: %s\n",
-          ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
     } else {
         ad_error_code=AD_SUCCESS;
@@ -1014,7 +1007,7 @@ int ad_group_create(LDAP *ds, const char *group_name, const char *dn) {
 
     result = ldap_add_ext_s(ds, dn, attrs, NULL, NULL);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ldap_add_ext_s: %s", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
     } else {
         ad_error_code=AD_SUCCESS;
@@ -1061,9 +1054,7 @@ int ad_group_subtree_remove_user(LDAP *ds, const char *container_dn, const char 
         LDAP_NO_LIMIT,
         &res);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, 
-            "Error in ldap_search_ext_s for ad_group_subtree_remove_user: %s", 
-            ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
         return ad_error_code;
     }
@@ -1079,10 +1070,6 @@ int ad_group_subtree_remove_user(LDAP *ds, const char *container_dn, const char 
     while(entry!=NULL) {
         group_dn=ldap_get_dn(ds, entry);
         if(ad_group_remove_user(ds, group_dn, user_dn)!=AD_SUCCESS) {
-            snprintf(ad_error_msg, MAX_ERR_LENGTH, 
-                "Error in ad_group_subtree_remove_user"
-                "\nwhen removing %s from %s:\n%s", 
-                user_dn, group_dn, ad_error_msg);
             return ad_error_code;
         }
         entry=ldap_next_entry(ds, entry);
@@ -1124,10 +1111,8 @@ int ad_ou_create(LDAP *ds, const char *ou_name, const char *dn) {
 
     result = ldap_add_ext_s(ds, dn, attrs, NULL, NULL);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH, "Error in ldap_add_ext_s: %s", ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
-    } else {
-        ad_error_code=AD_SUCCESS;
     }
 
     free(name_values[0]);
@@ -1162,9 +1147,7 @@ char **ad_list(LDAP *ds, const char *dn) {
         LDAP_NO_LIMIT,
         &res);
     if(result!=LDAP_SUCCESS) {
-        snprintf(ad_error_msg, MAX_ERR_LENGTH,
-            "Error in ldap_search_ext_s for ad_list: %s",
-            ldap_err2string(result));
+        save_error_msg(result);
         ad_error_code=AD_LDAP_OPERATION_FAILURE;
         return NULL;
     }


### PR DESCRIPTION
Replace handwritten sprintf's everywhere with macros that report function name, line and error automatically. Some errors are not related to LDAP functions, so added plain string message option as well for those.