### PR TITLE
Better caching

### DIFF
--- a/adldap/ad_connection.cpp
+++ b/adldap/ad_connection.cpp
@@ -48,6 +48,14 @@ int AdConnection::get_errcode() {
     return ad_get_error_num();
 }
 
+std::string AdConnection::get_search_base() const {
+    return search_base;
+}
+
+std::string AdConnection::get_uri() const {
+    return uri;
+}
+
 int AdConnection::create_user(const char *username, const char *dn) {
     return ad_create_user(ldap_connection, username, dn);
 }

--- a/adldap/include/ad_connection.h
+++ b/adldap/include/ad_connection.h
@@ -37,6 +37,8 @@ public:
     bool is_connected();
     char* get_errstr();
     int get_errcode();
+    std::string get_search_base() const;
+    std::string get_uri() const;
 
     int create_user(const char *username, const char *dn);
     int create_computer(const char *name, const char *dn);

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -77,6 +77,14 @@ QString AdInterface::get_error_str() {
     return QString(connection->get_errstr());
 }
 
+QString AdInterface::get_search_base() {
+    return QString::fromStdString(connection->get_search_base());
+}
+
+QString AdInterface::get_uri() {
+    return QString::fromStdString(connection->get_uri());
+}
+
 QList<QString> AdInterface::load_children(const QString &dn) {
     const QByteArray dn_array = dn.toLatin1();
     const char *dn_cstr = dn_array.constData();

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -183,18 +183,15 @@ Attributes AdInterface::load_attributes(const QString &dn) {
 }
 
 Attributes AdInterface::get_attributes(const QString &dn) {
-    Attributes attributes;
-
     if (dn == "") {
-        attributes = Attributes();
-    } else if (attributes_cache.contains(dn)) {
-        attributes = attributes_cache[dn];
-    } else {
-        attributes = load_attributes(dn);
-        attributes_cache[dn] = attributes;
+        return Attributes();
     }
 
-    return attributes;
+    if (!attributes_cache.contains(dn)) {
+        attributes_cache[dn] = load_attributes(dn);
+    }
+
+    return attributes_cache[dn];
 }
 
 QList<QString> AdInterface::get_attribute_multi(const QString &dn, const QString &attribute) {

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -21,9 +21,6 @@
 #include "ad_connection.h"
 #include "admc.h"
 
-#include <QSet>
-#include <algorithm>
-
 AdInterface::AdInterface(QObject *parent)
 : QObject(parent)
 {

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -242,9 +242,6 @@ bool AdInterface::set_attribute(const QString &dn, const QString &attribute, con
     result = connection->mod_replace(dn_cstr, attribute_cstr, value_cstr);
 
     if (result == AD_SUCCESS) {
-        // Reload attributes to get new value
-        load_attributes(dn);
-        
         emit set_attribute_complete(dn, attribute, old_value, value);
         emit modified();
 

--- a/src/ad_interface.cpp
+++ b/src/ad_interface.cpp
@@ -242,6 +242,8 @@ bool AdInterface::set_attribute(const QString &dn, const QString &attribute, con
         emit attributes_changed(dn);
         emit set_attribute_complete(dn, attribute, old_value, value);
 
+        emit modified();
+
         return true;
     } else {
         emit set_attribute_failed(dn, attribute, old_value, value, get_error_str());
@@ -283,6 +285,8 @@ bool AdInterface::create_entry(const QString &name, const QString &dn, NewEntryT
     if (result == AD_SUCCESS) {
         emit create_entry_complete(dn, type);
 
+        emit modified();
+
         return true;
     } else {
         emit create_entry_failed(dn, type, get_error_str());
@@ -301,6 +305,8 @@ void AdInterface::delete_entry(const QString &dn) {
 
     if (result == AD_SUCCESS) {
         update_cache(dn, "");
+
+        emit modified();
 
         emit delete_entry_complete(dn);
     } else {
@@ -333,6 +339,8 @@ void AdInterface::move(const QString &dn, const QString &new_container) {
     if (result == AD_SUCCESS) {
         update_cache(dn, new_dn);
 
+        emit modified();
+
         emit move_complete(dn, new_container, new_dn);
     } else {
         emit move_failed(dn, new_container, new_dn, get_error_str());
@@ -355,6 +363,8 @@ void AdInterface::add_user_to_group(const QString &group_dn, const QString &user
         add_attribute_internal(group_dn, "member", user_dn);
         add_attribute_internal(user_dn, "memberOf", group_dn);
 
+        emit modified();
+
         emit add_user_to_group_complete(group_dn, user_dn);
     } else {
         emit add_user_to_group_failed(group_dn, user_dn, get_error_str());
@@ -376,6 +386,8 @@ void AdInterface::group_remove_user(const QString &group_dn, const QString &user
         // Update attributes of user and group
         remove_attribute_internal(group_dn, "member", user_dn);
         remove_attribute_internal(user_dn, "memberOf", group_dn);
+
+        emit modified();
 
         emit group_remove_user_complete(group_dn, user_dn);
     } else {
@@ -412,6 +424,8 @@ void AdInterface::rename(const QString &dn, const QString &new_name) {
 
     if (result == AD_SUCCESS) {
         update_cache(dn, new_dn);
+
+        emit modified();
 
         emit rename_complete(dn, new_name, new_dn);
     } else {

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -95,6 +95,8 @@ public:
     void command(QStringList args);
 
 signals:
+    void modified();
+
     // NOTE: signals below are mostly for logging with few exceptions
     // like login/create_entry
     // For state updates you MUST use dn_changed() and

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -57,6 +57,8 @@ const QMap<NewEntryType, QString> new_entry_type_to_string = {
 QString extract_name_from_dn(const QString &dn);
 QString extract_parent_dn_from_dn(const QString &dn);
 
+typedef QMap<QString, QList<QString>> Attributes;
+
 class AdInterface final : public QObject {
 Q_OBJECT
 
@@ -69,7 +71,8 @@ public:
 
     QList<QString> load_children(const QString &dn);
     QList<QString> search(const QString &filter);
-    QMap<QString, QList<QString>> get_attributes(const QString &dn);
+
+    Attributes get_attributes(const QString &dn);
     QList<QString> get_attribute_multi(const QString &dn, const QString &attribute);
     QString get_attribute(const QString &dn, const QString &attribute);
     bool attribute_value_exists(const QString &dn, const QString &attribute, const QString &value);
@@ -150,7 +153,9 @@ private:
     QMap<QString, QMap<QString, QList<QString>>> attributes_map;
     QSet<QString> attributes_loaded;
 
-    void load_attributes(const QString &dn);
+    QHash<QString, Attributes> attributes_cache;
+
+    QMap<QString, QList<QString>> load_attributes(const QString &dn);
     void update_cache(const QString &old_parent_dn, const QString &new_parent_dn);
     void add_attribute_internal(const QString &dn, const QString &attribute, const QString &value);
     void remove_attribute_internal(const QString &dn, const QString &attribute, const QString &value);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -102,10 +102,6 @@ public:
 signals:
     void modified();
 
-    // NOTE: signals below are mostly for logging with few exceptions
-    // like login/create_entry
-    // For state updates you MUST use dn_changed() and
-    // attributes_changed() signals
     void ad_interface_login_complete(const QString &base, const QString &head);
     void ad_interface_login_failed(const QString &base, const QString &head);
 
@@ -137,30 +133,11 @@ signals:
     void rename_complete(const QString &dn, const QString &new_name, const QString &new_dn);
     void rename_failed(const QString &dn, const QString &new_name, const QString &new_dn, const QString &error_str);
 
-    // NOTE: if dn and attributes are changed together, for example
-    // due to a rename, dn_changed() signal is emitted first
-    
-    // NOTE: If multiple DN's are changed, for example by moving
-    // an entry which has children, dn_changed() is emmited for all
-    // entries that were moved and it is emmitted in order of depth
-    // starting from lowest depth
-
-    // NOTE: dn_changed() is emitted when entry is deleted with
-    // new_dn set to ""
-    void dn_changed(const QString &old_dn, const QString &new_dn);
-    void attributes_changed(const QString &dn);
-
 private:
     adldap::AdConnection *connection = nullptr;
-    QMap<QString, QMap<QString, QList<QString>>> attributes_map;
-    QSet<QString> attributes_loaded;
-
     QHash<QString, Attributes> attributes_cache;
 
     QMap<QString, QList<QString>> load_attributes(const QString &dn);
-    void update_cache(const QString &old_parent_dn, const QString &new_parent_dn);
-    void add_attribute_internal(const QString &dn, const QString &attribute, const QString &value);
-    void remove_attribute_internal(const QString &dn, const QString &attribute, const QString &value);
 
 }; 
 

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -68,6 +68,8 @@ public:
 
     void ad_interface_login(const QString &base, const QString &head);
     QString get_error_str();
+    QString get_search_base();
+    QString get_uri();
 
     QList<QString> load_children(const QString &dn);
     QList<QString> search(const QString &filter);

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -24,7 +24,7 @@
 #include <QList>
 #include <QString>
 #include <QMap>
-#include <QSet>
+#include <QHash>
 
 class AdConnection;
 

--- a/src/ad_interface.h
+++ b/src/ad_interface.h
@@ -109,9 +109,6 @@ signals:
 
     void search_failed(const QString &filter, const QString &error_str);
 
-    void load_attributes_complete(const QString &dn);
-    void load_attributes_failed(const QString &dn, const QString &error_str);
-
     void delete_entry_complete(const QString &dn);
     void delete_entry_failed(const QString &dn, const QString &error_str);
 

--- a/src/containers_widget.cpp
+++ b/src/containers_widget.cpp
@@ -109,14 +109,8 @@ ContainersModel::ContainersModel(QObject *parent)
         AD(), &AdInterface::ad_interface_login_complete,
         this, &ContainersModel::on_ad_interface_login_complete);
     connect(
-        AD(), &AdInterface::dn_changed,
-        this, &ContainersModel::on_dn_changed);
-    connect(
-        AD(), &AdInterface::create_entry_complete,
-        this, &ContainersModel::on_create_entry_complete);
-    connect(
-        AD(), &AdInterface::attributes_changed,
-        this, &ContainersModel::on_attributes_changed);
+        AD(), &AdInterface::modified,
+        this, &ContainersModel::on_ad_modified);
 }
 
 bool ContainersModel::canFetchMore(const QModelIndex &parent) const {
@@ -167,72 +161,14 @@ void ContainersModel::on_ad_interface_login_complete(const QString &search_base,
     make_new_row(invis_root, head_dn);
 }
 
-void ContainersModel::on_dn_changed(const QString &old_dn, const QString &new_dn) {
-    const QString old_parent_dn = extract_parent_dn_from_dn(old_dn);
-    const QString new_parent_dn = extract_parent_dn_from_dn(new_dn);
+void ContainersModel::on_ad_modified() {
+    removeRows(0, rowCount());
 
-    QStandardItem *old_parent = find_item(old_parent_dn, 0);
-    QStandardItem *new_parent = find_item(new_parent_dn, 0);
+    const QString head_dn = AD()->get_search_base();
 
-    QStandardItem *old_dn_item = find_item(old_dn, ContainersColumn_DN);
-    if (old_dn_item != nullptr) {
-        // Update DN
-        if (new_dn != "") {
-            old_dn_item->setText(new_dn);
-        }
-
-        // If parent of row is already new parent, don't need to move row
-        // This happens when entry was moved together with it's parent
-        // or ancestor
-        // Also true if entry was only renamed
-        if (old_dn_item->parent() == new_parent) {
-            return;
-        }
-    }
-
-    // NOTE: only add to new parent if it can't fetch
-    // if new parent can fetch, then it will load this row when
-    // it does fetch along with all other children
-    const bool remove_from_old_parent = (old_parent != nullptr && old_dn_item != nullptr);
-    const bool add_to_new_parent = (new_parent != nullptr && !canFetchMore(new_parent->index()));
-
-    if (remove_from_old_parent) {
-        const int old_row_i = old_dn_item->row();
-
-        if (add_to_new_parent) {
-            // Transfer row from old to new parent
-            const QList<QStandardItem *> row = old_parent->takeRow(old_row_i);
-            new_parent->appendRow(row);
-        } else {
-            old_parent->removeRow(old_row_i);
-        }
-    } else {
-        if (add_to_new_parent) {
-            make_new_row(new_parent, new_dn);
-        }
-    }
-}
-
-void ContainersModel::on_create_entry_complete(const QString &dn, NewEntryType type) {
-    // Load entry to model if it's parent has already been fetched
-    QString parent_dn = extract_parent_dn_from_dn(dn);
-    QStandardItem *parent = find_item(parent_dn, 0);
-
-    if (parent != nullptr) {
-        const QModelIndex parent_index = parent->index();
-
-        if (!canFetchMore(parent_index)) {
-            make_new_row(parent, dn);
-        }
-    }
-}
-
-void ContainersModel::on_attributes_changed(const QString &dn) {
-    QList<QStandardItem *> row = find_row(dn);
-
-    if (!row.isEmpty()) {
-        load_row(row, dn);
-    }
+    // Load head
+    QStandardItem *invis_root = invisibleRootItem();
+    make_new_row(invis_root, head_dn);
 }
 
 void load_row(QList<QStandardItem *> row, const QString &dn) {

--- a/src/containers_widget.h
+++ b/src/containers_widget.h
@@ -65,9 +65,7 @@ public:
 
 private slots:
     void on_ad_interface_login_complete(const QString &search_base, const QString &head_dn);
-    void on_attributes_changed(const QString &dn);
-    void on_dn_changed(const QString &old_dn, const QString &new_dn);
-    void on_create_entry_complete(const QString &dn, NewEntryType type); 
+    void on_ad_modified();
 };
 
 #endif /* CONTAINERS_WIDGET_H */

--- a/src/contents_widget.h
+++ b/src/contents_widget.h
@@ -44,6 +44,7 @@ signals:
 
 private slots:
     void on_containers_selected_changed(const QString &dn);
+    void on_ad_modified();
 
 private:
     ContentsModel *model = nullptr;
@@ -55,17 +56,14 @@ class ContentsModel final : public EntryModel {
 Q_OBJECT
 
 public:
+    // TODO: make this private again, will need to move slots into model?
+    QString target_dn = "";
+
     ContentsModel(QObject *parent);
 
     void change_target(const QString &dn);
 
-private slots:
-    void on_create_entry_complete(const QString &dn, NewEntryType type);
-    void on_dn_changed(const QString &old_dn, const QString &new_dn);
-    void on_attributes_changed(const QString &dn);
-
 private:
-    QString target_dn = "";
 
     void load_row(QList<QStandardItem *> row, const QString &dn);
     void make_new_row(QStandardItem *parent, const QString &dn);

--- a/src/details_widget.cpp
+++ b/src/details_widget.cpp
@@ -44,11 +44,8 @@ DetailsWidget::DetailsWidget(EntryContextMenu *entry_context_menu, ContainersWid
         AD(), &AdInterface::ad_interface_login_complete,
         this, &DetailsWidget::on_ad_interface_login_complete);
     connect(
-        AD(), &AdInterface::dn_changed,
-        this, &DetailsWidget::on_dn_changed);
-    connect(
-        AD(), &AdInterface::attributes_changed,
-        this, &DetailsWidget::on_attributes_changed);
+        AD(), &AdInterface::modified,
+        this, &DetailsWidget::on_ad_modified);
 
     connect(
         entry_context_menu, &EntryContextMenu::details,
@@ -95,23 +92,8 @@ void DetailsWidget::on_ad_interface_login_complete(const QString &search_base, c
     change_target("");
 }
 
-void DetailsWidget::on_dn_changed(const QString &old_dn, const QString &new_dn) {
-    if (target_dn == old_dn) {
-        if (new_dn == "") {
-            // Target was deleted so clear
-            change_target("");
-        } else {
-            // Switch to entry at new dn (entry stays the same)
-            change_target(new_dn);
-        }
-    }
-}
-
-void DetailsWidget::on_attributes_changed(const QString &dn) {
-    // Reload entry since attributes were updated
-    if (target_dn == dn) {
-        change_target(dn);
-    }
+void DetailsWidget::on_ad_modified() {
+    change_target(target_dn);
 }
 
 void DetailsWidget::on_containers_clicked_dn(const QString &dn) {

--- a/src/details_widget.h
+++ b/src/details_widget.h
@@ -46,8 +46,7 @@ public slots:
 
 private slots:
     void on_ad_interface_login_complete(const QString &search_base, const QString &head_dn);
-    void on_dn_changed(const QString &old_dn, const QString &new_dn); 
-    void on_attributes_changed(const QString &dn);
+    void on_ad_modified();
 
 private:
     AttributesWidget *attributes_widget = nullptr;

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -61,12 +61,6 @@ Status::Status(QStatusBar *status_bar_arg, QTextEdit *status_log_arg, QObject *p
         });
 
     connect(
-        AD(), &AdInterface::load_attributes_failed,
-        [this] (const QString &dn, const QString &error_str) {
-            message(QString("Failed to load attributes of \"%1\". Error: \"%2\"").arg(dn, error_str));
-        });
-
-    connect(
         AD(), &AdInterface::delete_entry_complete,
         [this] (const QString &dn) {
             message(QString("Deleted entry \"%1\"").arg(dn));


### PR DESCRIPTION
Current cache is too complex and causes problems.
Changed cache to only be valid between modifications. When attributes or entries are modified, cache is invalidated completely.
So on each operation that modifies AD, all the widgets are reloaded completely.
For now Containers doesn't keep expansion state.