### PR TITLE
Better settings

### DIFF
--- a/src/advanced_view_proxy.cpp
+++ b/src/advanced_view_proxy.cpp
@@ -30,13 +30,15 @@ AdvancedViewProxy::AdvancedViewProxy(int dn_column_arg, QObject *parent)
 {
     dn_column = dn_column_arg;
 
+    const QAction *advanced_view_action = SETTINGS()->checkable(SettingsCheckable_AdvancedView);
     connect(
-        SETTINGS()->checkable(SettingsCheckable_AdvancedView), &QAction::toggled,
+        advanced_view_action, &QAction::toggled,
         this, &AdvancedViewProxy::on_advanced_view_toggled);
 }
 
 void AdvancedViewProxy::on_advanced_view_toggled(bool) {
-    advanced_view_is_on = SETTINGS()->checkable(SettingsCheckable_AdvancedView)->isChecked();
+    const QAction *advanced_view_action = SETTINGS()->checkable(SettingsCheckable_AdvancedView);
+    advanced_view_is_on = advanced_view_action->isChecked();
 
     invalidateFilter();
 }

--- a/src/advanced_view_proxy.cpp
+++ b/src/advanced_view_proxy.cpp
@@ -31,12 +31,12 @@ AdvancedViewProxy::AdvancedViewProxy(int dn_column_arg, QObject *parent)
     dn_column = dn_column_arg;
 
     connect(
-        SETTINGS()->toggle_advanced_view, &QAction::toggled,
+        SETTINGS()->checkable(SettingsCheckable_AdvancedView), &QAction::toggled,
         this, &AdvancedViewProxy::on_advanced_view_toggled);
 }
 
 void AdvancedViewProxy::on_advanced_view_toggled(bool) {
-    advanced_view_is_on = SETTINGS()->toggle_advanced_view->isChecked();
+    advanced_view_is_on = SETTINGS()->checkable(SettingsCheckable_AdvancedView)->isChecked();
 
     invalidateFilter();
 }

--- a/src/confirmation_dialog.cpp
+++ b/src/confirmation_dialog.cpp
@@ -24,7 +24,7 @@
 #include <QAction>
 
 bool confirmation_dialog(const QString &text, QWidget *parent) {
-    const QAction *confirm_actions = SETTINGS()->confirm_actions;
+    const QAction *confirm_actions = SETTINGS()->checkable(SettingsCheckable_ConfirmActions);
     const bool confirm_actions_checked = confirm_actions->isChecked();
     if (!confirm_actions_checked) {
         return true;

--- a/src/details_widget.cpp
+++ b/src/details_widget.cpp
@@ -115,13 +115,15 @@ void DetailsWidget::on_attributes_changed(const QString &dn) {
 }
 
 void DetailsWidget::on_containers_clicked_dn(const QString &dn) {
-    if (SETTINGS()->details_on_containers_click->isChecked()) {
+    const QAction *details_from_containers = SETTINGS()->checkable(SettingsCheckable_DetailsFromContainers);
+    if (details_from_containers->isChecked()) {
         change_target(dn);
     }
 }
 
 void DetailsWidget::on_contents_clicked_dn(const QString &dn) {
-    if (SETTINGS()->details_on_contents_click->isChecked()) {
+    const QAction *details_from_contents = SETTINGS()->checkable(SettingsCheckable_DetailsFromContents);
+    if (details_from_contents->isChecked()) {
         change_target(dn);
     }
 }

--- a/src/dn_column_proxy.cpp
+++ b/src/dn_column_proxy.cpp
@@ -27,8 +27,9 @@ DnColumnProxy::DnColumnProxy(int dn_column_arg, QObject *parent)
 {
     dn_column = dn_column_arg;
 
+    const QAction *dn_column_action = SETTINGS()->checkable(SettingsCheckable_DnColumn);
     connect(
-        SETTINGS()->toggle_show_dn_column, &QAction::toggled,
+        dn_column_action, &QAction::toggled,
         this, &DnColumnProxy::on_toggle_show_dn_column);
 }
 

--- a/src/main_window.cpp
+++ b/src/main_window.cpp
@@ -63,6 +63,13 @@ MainWindow::MainWindow(const bool auto_login)
 
     // Menubar
     {
+        QAction *advanced_view = SETTINGS()->checkable(SettingsCheckable_AdvancedView);
+        QAction *show_dn_column = SETTINGS()->checkable(SettingsCheckable_DnColumn);
+        QAction *show_status_log = SETTINGS()->checkable(SettingsCheckable_ShowStatusLog);
+        QAction *details_from_containers = SETTINGS()->checkable(SettingsCheckable_DetailsFromContainers);
+        QAction *details_from_contents = SETTINGS()->checkable(SettingsCheckable_DetailsFromContents);
+        QAction *confirm_actions = SETTINGS()->checkable(SettingsCheckable_ConfirmActions);
+
         QMenuBar *menubar = menuBar();
         QMenu *menubar_file = menubar->addMenu("File");
         menubar_file->addAction("Login", []() {
@@ -73,14 +80,14 @@ MainWindow::MainWindow(const bool auto_login)
         });
 
         QMenu *menubar_view = menubar->addMenu("View");
-        menubar_view->addAction(SETTINGS()->toggle_advanced_view);
-        menubar_view->addAction(SETTINGS()->toggle_show_dn_column);
-        menubar_view->addAction(SETTINGS()->toggle_show_status_log);
+        menubar_view->addAction(advanced_view);
+        menubar_view->addAction(show_dn_column);
+        menubar_view->addAction(show_status_log);
 
         QMenu *menubar_preferences = menubar->addMenu("Preferences");
-        menubar_preferences->addAction(SETTINGS()->details_on_containers_click);
-        menubar_preferences->addAction(SETTINGS()->details_on_contents_click);
-        menubar_preferences->addAction(SETTINGS()->confirm_actions);
+        menubar_preferences->addAction(details_from_containers);
+        menubar_preferences->addAction(details_from_contents);
+        menubar_preferences->addAction(confirm_actions);
     }
 
     // Widgets

--- a/src/move_dialog.cpp
+++ b/src/move_dialog.cpp
@@ -258,8 +258,8 @@ void MoveDialogModel::load(const QString &dn, QList<ClassFilter> classes) {
         QString filter = filter_EQUALS("objectClass", class_string);
 
         // Filter out advanced entries if needed
-        const QAction *const toggle_advanced_view = SETTINGS()->toggle_advanced_view;
-        const bool advanced_view_is_off = !toggle_advanced_view->isChecked();
+        const QAction *advanced_view_action = SETTINGS()->checkable(SettingsCheckable_AdvancedView);
+        const bool advanced_view_is_off = !advanced_view_action->isChecked();
 
         if (advanced_view_is_off) {
             const QString is_advanced = filter_EQUALS("showInAdvancedViewOnly", "TRUE");

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -76,7 +76,7 @@ void Settings::emit_toggle_signals() const {
     }
 }
 
-QAction *checkable(SettingsCheckable c) const {
+const QAction *checkable(SettingsCheckable c) const {
     return checkables[c];
 }
 

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -60,7 +60,7 @@ Settings::Settings(QObject *parent)
         bool checked = settings.value(text, false).toBool();
         action->setChecked(checked);
 
-        checkables[checkable] = action;
+        checkables[i] = action;
     }
 
     // Save settings before the app quits
@@ -70,7 +70,7 @@ Settings::Settings(QObject *parent)
 }
 
 void Settings::emit_toggle_signals() const {
-    for (auto c : checkables.values()) {
+    for (auto c : checkables) {
         const bool checked = c->isChecked();
         emit c->toggled(checked);
     }
@@ -84,7 +84,7 @@ void Settings::save_settings() {
     const QString settings_file_path = get_settings_file_path();
     QSettings settings(settings_file_path, QSettings::NativeFormat);
 
-    for (auto c : checkables.values()) {
+    for (auto c : checkables) {
         const bool checked = c->isChecked();
         const QString text = c->text();
         settings.setValue(text, checked);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -25,17 +25,17 @@
 #include <QApplication>
 #include <QList>
 
-QAction *Settings::make_checkable_action(const QSettings &settings, const QString& text) {
-    QAction *action = new QAction(text);
-    action->setCheckable(true);
-
-    // Load checked state from settings
-    bool checked = settings.value(text, false).toBool();
-    action->setChecked(checked);
-
-    checkable_actions.append(action);
-
-    return action;
+QString checkable_text(SettingsCheckable checkable) {
+    switch (checkable) {
+        case SettingsCheckable_AdvancedView: return "Advanced View";
+        case SettingsCheckable_DnColumn: return "Show DN column";
+        case SettingsCheckable_DetailsFromContainers: return "Open attributes on left click in Containers window";
+        case SettingsCheckable_DetailsFromContents: return "Open attributes on left click in Contents window";
+        case SettingsCheckable_ConfirmActions: return "Confirm actions";
+        case SettingsCheckable_ShowStatusLog: return "Show status log";
+        case SettingsCheckable_COUNT: return "COUNT";
+    }
+    return "";
 }
 
 QString get_settings_file_path() {
@@ -50,12 +50,18 @@ Settings::Settings(QObject *parent)
     const QString settings_file_path = get_settings_file_path();
     const QSettings settings(settings_file_path, QSettings::NativeFormat);
     
-    toggle_advanced_view = make_checkable_action(settings, "Advanced View");
-    toggle_show_dn_column = make_checkable_action(settings, "Show DN column");
-    details_on_containers_click = make_checkable_action(settings, "Open attributes on left click in Containers window");
-    details_on_contents_click = make_checkable_action(settings, "Open attributes on left click in Contents window");
-    confirm_actions = make_checkable_action(settings, "Confirm actions");
-    toggle_show_status_log = make_checkable_action(settings, "Show status log");
+    for (int i = 0; i < SettingsCheckable_COUNT; i++) {
+        const SettingsCheckable checkable = (SettingsCheckable) i;
+        const QString text = checkable_text(checkable);
+
+        QAction *action = new QAction(text);
+        action->setCheckable(true);
+
+        bool checked = settings.value(text, false).toBool();
+        action->setChecked(checked);
+
+        checkables[checkable] = action;
+    }
 
     // Save settings before the app quits
     connect(
@@ -64,19 +70,23 @@ Settings::Settings(QObject *parent)
 }
 
 void Settings::emit_toggle_signals() const {
-    for (auto action : checkable_actions) {
-        const bool checked = action->isChecked();
-        emit action->toggled(checked);
+    for (auto c : checkables.values()) {
+        const bool checked = c->isChecked();
+        emit c->toggled(checked);
     }
+}
+
+QAction *checkable(SettingsCheckable c) const {
+    return checkables[c];
 }
 
 void Settings::save_settings() {
     const QString settings_file_path = get_settings_file_path();
     QSettings settings(settings_file_path, QSettings::NativeFormat);
 
-    for (auto action : checkable_actions) {
-        const bool checked = action->isChecked();
-        const QString text = action->text();
+    for (auto c : checkables.values()) {
+        const bool checked = c->isChecked();
+        const QString text = c->text();
         settings.setValue(text, checked);
     }
 }

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -76,7 +76,7 @@ void Settings::emit_toggle_signals() const {
     }
 }
 
-const QAction *checkable(SettingsCheckable c) const {
+QAction *Settings::checkable(SettingsCheckable c) const {
     return checkables[c];
 }
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -21,11 +21,21 @@
 #define SETTINGS_H
 
 #include <QObject>
-#include <QList>
+#include <QHash>
 
 class QAction;
 class QSettings;
 class QString;
+
+enum SettingsCheckable {
+    SettingsCheckable_AdvancedView,
+    SettingsCheckable_DnColumn,
+    SettingsCheckable_DetailsFromContainers,
+    SettingsCheckable_DetailsFromContents,
+    SettingsCheckable_ConfirmActions,
+    SettingsCheckable_ShowStatusLog,
+    SettingsCheckable_COUNT,
+};
 
 class Settings final : public QObject {
 Q_OBJECT
@@ -33,17 +43,10 @@ Q_OBJECT
 public:
     explicit Settings(QObject *parent);
     void emit_toggle_signals() const;
-
-    QAction *toggle_advanced_view = nullptr;
-    QAction *toggle_show_dn_column = nullptr;
-    QAction *details_on_containers_click = nullptr;
-    QAction *details_on_contents_click = nullptr;
-    QAction *confirm_actions = nullptr;
-    QAction *toggle_show_status_log = nullptr;
+    QAction *checkable(SettingsCheckable c) const;
 
 private:
-    QList<QAction *> checkable_actions;
-    QAction *make_checkable_action(const QSettings &settings, const QString& text);
+    QHash<SettingsCheckable, QAction *> checkables;
 
     void save_settings();
 

--- a/src/settings.h
+++ b/src/settings.h
@@ -42,7 +42,7 @@ Q_OBJECT
 public:
     explicit Settings(QObject *parent);
     void emit_toggle_signals() const;
-    QAction *checkable(SettingsCheckable c) const;
+    const QAction *checkable(SettingsCheckable c) const;
 
 private:
     QAction *checkables[SettingsCheckable_COUNT];

--- a/src/settings.h
+++ b/src/settings.h
@@ -42,7 +42,7 @@ Q_OBJECT
 public:
     explicit Settings(QObject *parent);
     void emit_toggle_signals() const;
-    const QAction *checkable(SettingsCheckable c) const;
+    QAction *checkable(SettingsCheckable c) const;
 
 private:
     QAction *checkables[SettingsCheckable_COUNT];

--- a/src/settings.h
+++ b/src/settings.h
@@ -21,7 +21,6 @@
 #define SETTINGS_H
 
 #include <QObject>
-#include <QHash>
 
 class QAction;
 class QSettings;
@@ -46,7 +45,7 @@ public:
     QAction *checkable(SettingsCheckable c) const;
 
 private:
-    QHash<SettingsCheckable, QAction *> checkables;
+    QAction *checkables[SettingsCheckable_COUNT];
 
     void save_settings();
 

--- a/src/status.cpp
+++ b/src/status.cpp
@@ -96,8 +96,9 @@ Status::Status(QStatusBar *status_bar_arg, QTextEdit *status_log_arg, QObject *p
         AD(), &AdInterface::rename_failed,
         this, &Status::on_rename_failed);
 
+    const QAction *show_status_log = SETTINGS()->checkable(SettingsCheckable_ShowStatusLog);
     connect(
-        SETTINGS()->toggle_show_status_log, &QAction::toggled,
+        show_status_log, &QAction::toggled,
         this, &Status::on_toggle_show_status_log);
 }
 


### PR DESCRIPTION
Add enums for settings checkables, similarly to how settings strings are done in #57.
This guarantees that all checkables are initialized and that their text is defined.